### PR TITLE
Allow weak biometric

### DIFF
--- a/android/src/main/java/ee/forgr/biometric/AuthActivity.java
+++ b/android/src/main/java/ee/forgr/biometric/AuthActivity.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.biometric.BiometricManager;
 import androidx.biometric.BiometricPrompt;
 import ee.forgr.biometric.capacitornativebiometric.R;
 import java.util.concurrent.Executor;
@@ -36,6 +37,7 @@ public class AuthActivity extends AppCompatActivity {
     }
 
     BiometricPrompt.PromptInfo.Builder builder = new BiometricPrompt.PromptInfo.Builder()
+      .setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_STRONG)
       .setTitle(
         getIntent().hasExtra("title")
           ? getIntent().getStringExtra("title")

--- a/android/src/main/java/ee/forgr/biometric/AuthActivity.java
+++ b/android/src/main/java/ee/forgr/biometric/AuthActivity.java
@@ -36,8 +36,14 @@ public class AuthActivity extends AppCompatActivity {
         };
     }
 
+    boolean isWeakAuthenticatorAllowed = getIntent().getBooleanExtra("isWeakAuthenticatorAllowed", false);
+
+    int allowedAuthenticators = BiometricManager.Authenticators.BIOMETRIC_STRONG;
+    if (isWeakAuthenticatorAllowed)
+      allowedAuthenticators = allowedAuthenticators | BiometricManager.Authenticators.BIOMETRIC_WEAK;
+
     BiometricPrompt.PromptInfo.Builder builder = new BiometricPrompt.PromptInfo.Builder()
-      .setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_STRONG)
+      .setAllowedAuthenticators(allowedAuthenticators)
       .setTitle(
         getIntent().hasExtra("title")
           ? getIntent().getStringExtra("title")

--- a/android/src/main/java/ee/forgr/biometric/NativeBiometric.java
+++ b/android/src/main/java/ee/forgr/biometric/NativeBiometric.java
@@ -116,8 +116,16 @@ public class NativeBiometric extends Plugin {
       call.getBoolean("useFallback", false)
     );
 
+    boolean isWeakAuthenticatorAllowed = Boolean.TRUE.equals(
+            call.getBoolean("isWeakAuthenticatorAllowed", false)
+    );
+
+    int allowedAuthenticators = BiometricManager.Authenticators.BIOMETRIC_STRONG;
+    if (isWeakAuthenticatorAllowed)
+      allowedAuthenticators = allowedAuthenticators | BiometricManager.Authenticators.BIOMETRIC_WEAK;
+
     BiometricManager biometricManager = BiometricManager.from(getContext());
-    int canAuthenticateResult = biometricManager.canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_STRONG);
+    int canAuthenticateResult = biometricManager.canAuthenticate(allowedAuthenticators);
     // Using deviceHasCredentials instead of canAuthenticate(DEVICE_CREDENTIAL)
     // > "Developers that wish to check for the presence of a PIN, pattern, or password on these versions should instead use isDeviceSecure."
     // @see https://developer.android.com/reference/androidx/biometric/BiometricManager#canAuthenticate(int)
@@ -178,6 +186,10 @@ public class NativeBiometric extends Plugin {
     }
 
     intent.putExtra("useFallback", useFallback);
+
+    if (call.hasOption("isWeakAuthenticatorAllowed")) {
+      intent.putExtra("isWeakAuthenticatorAllowed", call.getBoolean("isWeakAuthenticatorAllowed"));
+    }
 
     startActivityForResult(call, intent, "verifyResult");
   }

--- a/android/src/main/java/ee/forgr/biometric/NativeBiometric.java
+++ b/android/src/main/java/ee/forgr/biometric/NativeBiometric.java
@@ -117,7 +117,7 @@ public class NativeBiometric extends Plugin {
     );
 
     BiometricManager biometricManager = BiometricManager.from(getContext());
-    int canAuthenticateResult = biometricManager.canAuthenticate();
+    int canAuthenticateResult = biometricManager.canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_STRONG);
     // Using deviceHasCredentials instead of canAuthenticate(DEVICE_CREDENTIAL)
     // > "Developers that wish to check for the presence of a PIN, pattern, or password on these versions should instead use isDeviceSecure."
     // @see https://developer.android.com/reference/androidx/biometric/BiometricManager#canAuthenticate(int)

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "clean": "rimraf ./dist",
     "watch": "tsc --watch",
     "docgen": "docgen --api NativeBiometricPlugin --output-readme README.md --output-json dist/docs.json",
+    "prepare": "npm run build",
     "prepublishOnly": "npm run build"
   },
   "author": "Martin Donadieu",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -25,6 +25,12 @@ export interface IsAvailableOptions {
    * Specifies if should fallback to passcode authentication if biometric authentication is not available.
    */
   useFallback: boolean;
+  /**
+   * Only for Android.
+   * Set true, if the application already has active biometric authentication.
+   * This will allow the weak-authentication to prevent issues after updating application to newer versions.
+   */
+  isWeakAuthenticatorAllowed?: boolean;
 }
 
 export interface AvailableResult {
@@ -55,6 +61,12 @@ export interface BiometricOptions {
    * @default 1
    */
   maxAttempts?: number;
+  /**
+   * Only for Android.
+   * Set true, if the application already has active biometric authentication.
+   * This will allow the weak-authentication to prevent issues after updating application to newer versions.
+   */
+  isWeakAuthenticatorAllowed?: boolean;
 }
 
 export interface GetCredentialOptions {


### PR DESCRIPTION
Added isWeakAuthenticatorAllowed to the definitions to allow weak authentication if required.