### PR TITLE
Fixes #40 error on android if negativeButtonText is null

### DIFF
--- a/android/src/main/java/ee/forgr/biometric/AuthActivity.java
+++ b/android/src/main/java/ee/forgr/biometric/AuthActivity.java
@@ -70,16 +70,16 @@ public class AuthActivity extends AppCompatActivity {
     } else {
       if (useFallback) {
         builder.setDeviceCredentialAllowed(true);
-      } else {
-        builder.setNegativeButtonText(
-          getIntent().hasExtra("negativeButtonText")
-            ? Objects.requireNonNull(
-              getIntent().getStringExtra("negativeButtonText")
-            )
-            : "Cancel"
-        );
       }
     }
+    
+    builder.setNegativeButtonText(
+      getIntent().hasExtra("negativeButtonText")
+        ? Objects.requireNonNull(
+          getIntent().getStringExtra("negativeButtonText")
+        )
+        : "Cancel"
+    );
 
     BiometricPrompt.PromptInfo promptInfo = builder.build();
 


### PR DESCRIPTION
Fixes error on android if negativeButtonText is null #40 

Thanks to @Missile71

This is my first pull request to an OS project so my apologies if I did something incorrectly!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The biometric authentication prompt has been updated for a more consistent user experience. The cancel option is now always displayed during authentication, ensuring users have a clear and reliable way to exit the prompt when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->