### PR TITLE
Android: Cancel authentication prompt on "too many failed attempts"

### DIFF
--- a/android/src/main/java/ee/forgr/biometric/AuthActivity.java
+++ b/android/src/main/java/ee/forgr/biometric/AuthActivity.java
@@ -14,6 +14,7 @@ import java.util.concurrent.Executor;
 
 public class AuthActivity extends AppCompatActivity {
 
+  private BiometricPrompt biometricPrompt;
   private int maxAttempts;
   private int counter = 0;
 
@@ -76,7 +77,7 @@ public class AuthActivity extends AppCompatActivity {
 
     BiometricPrompt.PromptInfo promptInfo = builder.build();
 
-    BiometricPrompt biometricPrompt = new BiometricPrompt(
+    biometricPrompt = new BiometricPrompt(
       this,
       executor,
       new BiometricPrompt.AuthenticationCallback() {
@@ -112,6 +113,7 @@ public class AuthActivity extends AppCompatActivity {
           super.onAuthenticationFailed();
           counter++;
           if (counter >= maxAttempts) {
+            biometricPrompt.cancelAuthentication();
             // Use error code 4 for too many attempts to match iOS behavior
             finishActivity("error", 4, "Too many failed attempts");
           }


### PR DESCRIPTION
## Issue

Currently, when using `maxAttempts` < 5 on Android, the plugin finishes correctly with an error when reaching the counter but doesn't cancel the biometrics prompt.

This can lead to a confusing user experience as the app already canceled the action in the background while the system still prompts to authenticate.
And even if the user then authenticates successfully, it isn't reported back to the app.

## Fix

This PR calls [`BiometricPrompt#cancelAuthentication`](https://developer.android.com/reference/androidx/biometric/BiometricPrompt#cancelAuthentication()) after reaching `maxAttempts` in `onAuthenticationFailed`.

Unfortunately, the `biometricsPrompt` had to be moved to a class field, as Java doesn't allow access to an either possibly uninitialized or non-final variable.

Feel free to edit this PR to fit your guidelines regarding class fields!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the biometric authentication process to automatically cancel after repeated failed attempts, providing a more consistent and secure experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->