### PR TITLE
feat: add hardware-enforced biometric-protected credential storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ This is a plugin specific list of error codes that can be thrown on verifyIdenti
 * [`getCredentials(...)`](#getcredentials)
 * [`setCredentials(...)`](#setcredentials)
 * [`deleteCredentials(...)`](#deletecredentials)
+* [`getSecureCredentials(...)`](#getsecurecredentials)
 * [`isCredentialsSaved(...)`](#iscredentialssaved)
 * [`getPluginVersion()`](#getpluginversion)
 * [Interfaces](#interfaces)
@@ -405,6 +406,29 @@ Deletes the stored credentials for a given server.
 --------------------
 
 
+### getSecureCredentials(...)
+
+```typescript
+getSecureCredentials(options: GetSecureCredentialsOptions) => Promise<Credentials>
+```
+
+Gets the stored credentials for a given server, requiring biometric authentication.
+Credentials must have been stored with accessControl set to BIOMETRY_CURRENT_SET or BIOMETRY_ANY.
+
+On iOS, the system automatically shows the biometric prompt when accessing the protected Keychain item.
+On Android, BiometricPrompt is shown with a CryptoObject bound to the credential decryption key.
+
+| Param         | Type                                                                                |
+| ------------- | ----------------------------------------------------------------------------------- |
+| **`options`** | <code><a href="#getsecurecredentialsoptions">GetSecureCredentialsOptions</a></code> |
+
+**Returns:** <code>Promise&lt;<a href="#credentials">Credentials</a>&gt;</code>
+
+**Since:** 8.4.0
+
+--------------------
+
+
 ### isCredentialsSaved(...)
 
 ```typescript
@@ -502,11 +526,12 @@ Result from isAvailable() method indicating biometric authentication availabilit
 
 #### SetCredentialOptions
 
-| Prop           | Type                |
-| -------------- | ------------------- |
-| **`username`** | <code>string</code> |
-| **`password`** | <code>string</code> |
-| **`server`**   | <code>string</code> |
+| Prop                | Type                                                    | Description                                                                                                                                                                                                                                                                                                                                                                                             | Default                         | Since |
+| ------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- | ----- |
+| **`username`**      | <code>string</code>                                     |                                                                                                                                                                                                                                                                                                                                                                                                         |                                 |       |
+| **`password`**      | <code>string</code>                                     |                                                                                                                                                                                                                                                                                                                                                                                                         |                                 |       |
+| **`server`**        | <code>string</code>                                     |                                                                                                                                                                                                                                                                                                                                                                                                         |                                 |       |
+| **`accessControl`** | <code><a href="#accesscontrol">AccessControl</a></code> | Access control level for the stored credentials. When set to BIOMETRY_CURRENT_SET or BIOMETRY_ANY, the credentials are hardware-protected and require biometric authentication to access. On iOS, this adds SecAccessControl to the Keychain item. On Android, this creates a biometric-protected Keystore key and requires BiometricPrompt authentication for both storing and retrieving credentials. | <code>AccessControl.NONE</code> | 8.4.0 |
 
 
 #### DeleteCredentialOptions
@@ -514,6 +539,18 @@ Result from isAvailable() method indicating biometric authentication availabilit
 | Prop         | Type                |
 | ------------ | ------------------- |
 | **`server`** | <code>string</code> |
+
+
+#### GetSecureCredentialsOptions
+
+| Prop                     | Type                | Description                                                                                                |
+| ------------------------ | ------------------- | ---------------------------------------------------------------------------------------------------------- |
+| **`server`**             | <code>string</code> |                                                                                                            |
+| **`reason`**             | <code>string</code> | Reason for requesting biometric authentication. Displayed in the biometric prompt on both iOS and Android. |
+| **`title`**              | <code>string</code> | Title for the biometric prompt. Only for Android.                                                          |
+| **`subtitle`**           | <code>string</code> | Subtitle for the biometric prompt. Only for Android.                                                       |
+| **`description`**        | <code>string</code> | Description for the biometric prompt. Only for Android.                                                    |
+| **`negativeButtonText`** | <code>string</code> | Text for the negative/cancel button. Only for Android.                                                     |
 
 
 #### IsCredentialsSavedResult
@@ -583,6 +620,15 @@ Callback type for biometry change listener
 | **`SYSTEM_CANCEL`**           | <code>15</code> | System canceled the authentication (e.g., due to screen lock) Platform: Android, iOS  |
 | **`USER_CANCEL`**             | <code>16</code> | User canceled the authentication Platform: Android, iOS                               |
 | **`USER_FALLBACK`**           | <code>17</code> | User chose to use fallback authentication method Platform: Android, iOS               |
+
+
+#### AccessControl
+
+| Members                    | Value          | Description                                                                                                                                                                                                                   |
+| -------------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`NONE`**                 | <code>0</code> | No biometric protection. <a href="#credentials">Credentials</a> are accessible without authentication. This is the default behavior for backward compatibility.                                                               |
+| **`BIOMETRY_CURRENT_SET`** | <code>1</code> | Biometric authentication required for credential access. Credentials are invalidated if biometrics change (e.g., new fingerprint enrolled). More secure but credentials are lost if user modifies their biometric enrollment. |
+| **`BIOMETRY_ANY`**         | <code>2</code> | Biometric authentication required for credential access. Credentials survive new biometric enrollment (e.g., adding a new fingerprint). More lenient — recommended for most apps.                                             |
 
 </docgen-api>
 ## Face ID (iOS)

--- a/ios/Sources/NativeBiometricPlugin/NativeBiometricPlugin.swift
+++ b/ios/Sources/NativeBiometricPlugin/NativeBiometricPlugin.swift
@@ -20,6 +20,7 @@ public class NativeBiometricPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "getCredentials", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setCredentials", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "deleteCredentials", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getSecureCredentials", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "isCredentialsSaved", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getPluginVersion", returnType: CAPPluginReturnPromise)
     ]
@@ -190,20 +191,95 @@ public class NativeBiometricPlugin: CAPPlugin, CAPBridgedPlugin {
             return
         }
 
+        let accessControl = call.getInt("accessControl") ?? 0
         let credentials = Credentials(username: username, password: password)
 
-        do {
-            try storeCredentialsInKeychain(credentials, server)
-            call.resolve()
-        } catch KeychainError.duplicateItem {
+        if accessControl > 0 {
             do {
-                try updateCredentialsInKeychain(credentials, server)
+                try storeProtectedCredentials(credentials, server, accessControl)
                 call.resolve()
+            } catch KeychainError.duplicateItem {
+                do {
+                    try deleteProtectedCredentials(server)
+                    try storeProtectedCredentials(credentials, server, accessControl)
+                    call.resolve()
+                } catch {
+                    call.reject(error.localizedDescription)
+                }
             } catch {
                 call.reject(error.localizedDescription)
             }
-        } catch {
-            call.reject(error.localizedDescription)
+        } else {
+            do {
+                try storeCredentialsInKeychain(credentials, server)
+                call.resolve()
+            } catch KeychainError.duplicateItem {
+                do {
+                    try updateCredentialsInKeychain(credentials, server)
+                    call.resolve()
+                } catch {
+                    call.reject(error.localizedDescription)
+                }
+            } catch {
+                call.reject(error.localizedDescription)
+            }
+        }
+    }
+
+    @objc func getSecureCredentials(_ call: CAPPluginCall) {
+        guard let server = call.getString("server") else {
+            call.reject("No server name was provided")
+            return
+        }
+
+        let context = LAContext()
+        if let reason = call.getString("reason") {
+            context.localizedReason = reason
+        }
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: server,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+            kSecReturnAttributes as String: true,
+            kSecReturnData as String: true,
+            kSecUseAuthenticationContext as String: context
+        ]
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            var item: CFTypeRef?
+            let status = SecItemCopyMatching(query as CFDictionary, &item)
+
+            DispatchQueue.main.async {
+                if status == errSecUserCanceled {
+                    call.reject("User canceled biometric authentication", "16")
+                    return
+                }
+                guard status == errSecSuccess else {
+                    if status == errSecItemNotFound {
+                        call.reject("No protected credentials found for server", "21")
+                    } else if status == errSecAuthFailed {
+                        call.reject("Biometric authentication failed", "10")
+                    } else {
+                        call.reject("Failed to retrieve credentials: \(status)", "0")
+                    }
+                    return
+                }
+
+                guard let existingItem = item as? [String: Any],
+                      let passwordData = existingItem[kSecValueData as String] as? Data,
+                      let password = String(data: passwordData, encoding: .utf8),
+                      let username = existingItem[kSecAttrAccount as String] as? String
+                else {
+                    call.reject("Unexpected credential data")
+                    return
+                }
+
+                var obj = JSObject()
+                obj["username"] = username
+                obj["password"] = password
+                call.resolve(obj)
+            }
         }
     }
 
@@ -215,6 +291,7 @@ public class NativeBiometricPlugin: CAPPlugin, CAPBridgedPlugin {
 
         do {
             try deleteCredentialsFromKeychain(server)
+            try deleteProtectedCredentials(server)
             call.resolve()
         } catch {
             call.reject(error.localizedDescription)
@@ -228,11 +305,10 @@ public class NativeBiometricPlugin: CAPPlugin, CAPBridgedPlugin {
         }
 
         var obj = JSObject()
-        obj["isSaved"] = checkCredentialsExist(server)
+        obj["isSaved"] = checkCredentialsExist(server) || checkProtectedCredentialsExist(server)
         call.resolve(obj)
     }
 
-    // Check if credentials exist in Keychain
     func checkCredentialsExist(_ server: String) -> Bool {
         let query: [String: Any] = [kSecClass as String: kSecClassInternetPassword,
                                     kSecAttrServer as String: server,
@@ -242,7 +318,53 @@ public class NativeBiometricPlugin: CAPPlugin, CAPBridgedPlugin {
         return status == errSecSuccess
     }
 
-    // Store user Credentials in Keychain
+    func checkProtectedCredentialsExist(_ server: String) -> Bool {
+        let query: [String: Any] = [kSecClass as String: kSecClassGenericPassword,
+                                    kSecAttrService as String: server,
+                                    kSecMatchLimit as String: kSecMatchLimitOne]
+
+        let status = SecItemCopyMatching(query as CFDictionary, nil)
+        return status == errSecSuccess
+    }
+
+    func storeProtectedCredentials(_ credentials: Credentials, _ server: String, _ accessControl: Int) throws {
+        guard let passwordData = credentials.password.data(using: .utf8) else {
+            throw KeychainError.unexpectedPasswordData
+        }
+
+        let flags: SecAccessControlCreateFlags = accessControl == 1 ? .biometryCurrentSet : .biometryAny
+        guard let access = SecAccessControlCreateWithFlags(
+            kCFAllocatorDefault,
+            kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
+            flags,
+            nil
+        ) else {
+            throw KeychainError.unhandledError(status: errSecParam)
+        }
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: server,
+            kSecAttrAccount as String: credentials.username,
+            kSecValueData as String: passwordData,
+            kSecAttrAccessControl as String: access
+        ]
+
+        let status = SecItemAdd(query as CFDictionary, nil)
+        guard status != errSecDuplicateItem else { throw KeychainError.duplicateItem }
+        guard status == errSecSuccess else { throw KeychainError.unhandledError(status: status) }
+    }
+
+    func deleteProtectedCredentials(_ server: String) throws {
+        let query: [String: Any] = [kSecClass as String: kSecClassGenericPassword,
+                                    kSecAttrService as String: server]
+
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw KeychainError.unhandledError(status: status)
+        }
+    }
+
     func storeCredentialsInKeychain(_ credentials: Credentials, _ server: String) throws {
         guard let passwordData = credentials.password.data(using: .utf8) else {
             throw KeychainError.unexpectedPasswordData

--- a/src/web.ts
+++ b/src/web.ts
@@ -6,6 +6,7 @@ import type {
   AvailableResult,
   BiometricOptions,
   GetCredentialOptions,
+  GetSecureCredentialsOptions,
   SetCredentialOptions,
   DeleteCredentialOptions,
   IsCredentialsSavedOptions,
@@ -58,7 +59,15 @@ export class NativeBiometricWeb extends WebPlugin implements NativeBiometricPlug
 
   getCredentials(_options: GetCredentialOptions): Promise<Credentials> {
     console.log('getCredentials (dummy implementation)', { server: _options.server });
-    // Dummy implementation: retrieve from in-memory store
+    const credentials = this.credentialStore.get(_options.server);
+    if (!credentials) {
+      throw new Error('No credentials found for the specified server');
+    }
+    return Promise.resolve(credentials);
+  }
+
+  getSecureCredentials(_options: GetSecureCredentialsOptions): Promise<Credentials> {
+    console.log('getSecureCredentials (dummy implementation)', { server: _options.server });
     const credentials = this.credentialStore.get(_options.server);
     if (!credentials) {
       throw new Error('No credentials found for the specified server');


### PR DESCRIPTION
## Summary

- Adds `accessControl` option to `setCredentials()` enabling hardware-backed biometric protection for stored credentials
- Adds `getSecureCredentials()` method requiring biometric authentication to retrieve protected credentials
- Fully backward compatible — existing `setCredentials`/`getCredentials` behavior unchanged

## Motivation

Previously, `verifyIdentity()` (biometric prompt) and credential storage were completely decoupled. Credentials could be read without any biometric gate, relying on developers to chain `verifyIdentity()` before `getCredentials()`. This PR adds OS-level enforcement so protected credentials **cannot** be accessed without biometric authentication.

## API Changes

```typescript
// New enum
enum AccessControl {
  NONE = 0,                  // Default, existing behavior
  BIOMETRY_CURRENT_SET = 1,  // Currently enrolled biometrics only
  BIOMETRY_ANY = 2,          // Any enrolled biometrics
}

// Extended option
interface SetCredentialOptions {
  // ... existing fields
  accessControl?: AccessControl;  // NEW — enables biometric protection
}

// New method
getSecureCredentials(options: GetSecureCredentialsOptions): Promise<Credentials>
```

## Platform Implementation

### iOS
- Protected credentials stored as `kSecClassGenericPassword` with `SecAccessControlCreateWithFlags` (Secure Enclave)
- Uses `kSecAttrService` key (separate from existing `kSecClassInternetPassword` + `kSecAttrServer`)
- `getSecureCredentials` triggers OS biometric prompt automatically via `LAContext` + `kSecUseAuthenticationContext`
- Only **read** requires biometric (Keychain handles this natively)

### Android
- Credential key generated with `setUserAuthenticationRequired(true)` in Android Keystore
- `BiometricPrompt` with `CryptoObject` binding for both encrypt and decrypt
- Separate key alias (`NativeBiometricSecure_{server}`) and SharedPreferences key (`secure_{server}`)
- Both **store** and **retrieve** require biometric (Android platform constraint)

## Verification

- [x] `bun run build` — passes
- [x] `bun run verify:web` — passes
- [x] `bun run verify:ios` — BUILD SUCCEEDED
- [x] `bun run verify:android` — BUILD SUCCESSFUL
- [x] `bun run fmt` — applied
- [x] `bun run lint` — passes (1 warning: Swift file length 486/400, expected from new feature code)
- [x] Example app builds with new secure credentials section

## Note

Device testing required for biometric prompts — cannot be verified in CI. The example app includes a "Secure Credentials" section with Set/Get buttons for manual testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added biometric-protected credential storage with configurable access control levels (NONE, BIOMETRY_CURRENT_SET, BIOMETRY_ANY).
  * Secure credentials now require biometric authentication for retrieval.
  * New methods for storing and retrieving encrypted credentials via biometric verification.

* **Documentation**
  * Updated API documentation and example app to showcase biometric-protected credential functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->