### PR TITLE
fix(android): delete only requested server credentials (#95)

### DIFF
--- a/android/src/main/java/ee/forgr/biometric/NativeBiometric.java
+++ b/android/src/main/java/ee/forgr/biometric/NativeBiometric.java
@@ -423,7 +423,9 @@ public class NativeBiometric extends Plugin {
                 SharedPreferences.Editor editor = getContext()
                     .getSharedPreferences(NATIVE_BIOMETRIC_SHARED_PREFERENCES, Context.MODE_PRIVATE)
                     .edit();
-                editor.clear();
+                editor.remove(KEY_ALIAS + "-username");
+                editor.remove(KEY_ALIAS + "-password");
+                editor.remove("secure_" + KEY_ALIAS);
                 editor.apply();
 
                 try {


### PR DESCRIPTION
## Summary
- Replace `editor.clear()` in `deleteCredentials` with targeted `editor.remove()` calls for the requested server alias only.
- Prevents wiping credentials for other servers stored in the same SharedPreferences file.

Fixes Cap-go/capacitor-native-biometric#95

## Test plan
- [x] `bun run verify` (iOS, Android, web)
- [ ] Manual: save credentials for two servers, delete one, confirm the other remains

Made with [Cursor](https://cursor.com)