### PR TITLE
fix(isAvailable): reinstate biometryType in native response (#65)

### DIFF
--- a/android/src/main/java/ee/forgr/biometric/NativeBiometric.java
+++ b/android/src/main/java/ee/forgr/biometric/NativeBiometric.java
@@ -129,6 +129,10 @@ public class NativeBiometric extends Plugin {
         if (hasStrongBiometric) {
             authenticationStrength = AUTH_STRENGTH_STRONG;
             isAvailable = true;
+        } else if (hasWeakBiometric) {
+            // Weak-only biometrics (e.g. some face unlock) are reported for UX via
+            // biometryType/authenticationStrength but do not enable verifyIdentity().
+            authenticationStrength = AUTH_STRENGTH_WEAK;
         } else if (fallbackAvailable) {
             authenticationStrength = AUTH_STRENGTH_WEAK;
             isAvailable = true;

--- a/example-app/src/js/biometric-tester.js
+++ b/example-app/src/js/biometric-tester.js
@@ -3,6 +3,7 @@ import { Capacitor } from '@capacitor/core';
 import {
   NativeBiometric,
   AuthenticationStrength,
+  BiometryType,
   AccessControl,
 } from '@capgo/capacitor-native-biometric';
 import { SplashScreen } from '@capacitor/splash-screen';
@@ -295,6 +296,29 @@ function createBiometricTester() {
   elements.getSecureCredentials.addEventListener('click', getSecureCredentials);
   elements.executeDebug.addEventListener('click', executeDebug);
 
+
+  function getBiometryTypeName(type) {
+    switch (type) {
+      case BiometryType.TOUCH_ID:
+        return 'Touch ID';
+      case BiometryType.FACE_ID:
+        return 'Face ID';
+      case BiometryType.FINGERPRINT:
+        return 'Fingerprint';
+      case BiometryType.FACE_AUTHENTICATION:
+        return 'Face authentication';
+      case BiometryType.IRIS_AUTHENTICATION:
+        return 'Iris authentication';
+      case BiometryType.MULTIPLE:
+        return 'Multiple biometry types';
+      case BiometryType.DEVICE_CREDENTIAL:
+        return 'Device credential (PIN/pattern/password)';
+      case BiometryType.NONE:
+      default:
+        return 'None';
+    }
+  }
+
   // Functions
   async function checkAvailability() {
     try {
@@ -303,18 +327,24 @@ function createBiometricTester() {
       const result = await NativeBiometric.isAvailable({ useFallback });
       addConsoleLog('INFO', ['Availability result:', result]);
 
+      const biometryName = getBiometryTypeName(result.biometryType);
+      const strengthName = getAuthenticationStrengthName(result.authenticationStrength);
+
       if (result.isAvailable) {
-        const strengthName = getAuthenticationStrengthName(result.authenticationStrength);
-        elements.biometricStatus.textContent = `✅ Biometrics Available (${strengthName})`;
+        elements.biometricStatus.textContent = `✅ Biometrics Available (${biometryName}, ${strengthName})`;
         elements.biometricStatus.className = 'status available';
-        elements.biometricInfo.style.display = 'block';
-        elements.biometricInfo.innerHTML = `<strong>Authentication Strength:</strong> ${strengthName} (${result.authenticationStrength})`;
       } else {
-        elements.biometricStatus.textContent = `❌ Biometrics Not Available (Error: ${result.errorCode || 'Unknown'})`;
+        elements.biometricStatus.textContent = `❌ Biometrics Not Available (${biometryName}, ${strengthName})`;
         elements.biometricStatus.className = 'status unavailable';
-        elements.biometricInfo.style.display = 'block';
-        elements.biometricInfo.innerHTML = `<strong>Error Code:</strong> ${result.errorCode || 'Unknown'}`;
       }
+
+      elements.biometricInfo.style.display = 'block';
+      elements.biometricInfo.innerHTML = `
+        <strong>Biometry type:</strong> ${biometryName} (${result.biometryType})<br>
+        <strong>Authentication strength:</strong> ${strengthName} (${result.authenticationStrength})<br>
+        <strong>Strong biometry available:</strong> ${result.strongBiometryIsAvailable ? 'Yes' : 'No'}<br>
+        <strong>Device secure:</strong> ${result.deviceIsSecure ? 'Yes' : 'No'}${result.errorCode !== undefined ? `<br><strong>Error code:</strong> ${result.errorCode}` : ''}
+      `;
     } catch (error) {
       addConsoleLog('ERROR', ['Availability check failed:', error]);
       elements.biometricStatus.textContent = '❌ Check Failed';

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://capgo.app/docs/plugins/native-biometric/",
   "scripts": {
-    "verify": "bun run verify:ios && bun run verify:android && bun run verify:web",
+    "verify": "bun run check:is-available && bun run verify:ios && bun run verify:android && bun run verify:web",
     "verify:ios": "xcodebuild -scheme CapgoCapacitorNativeBiometric -destination generic/platform=iOS",
     "verify:android": "cd android && ./gradlew clean build test && cd ..",
     "verify:web": "bun run build",
@@ -50,7 +50,8 @@
     "prepublishOnly": "bun run build",
     "check:wiring": "node scripts/check-capacitor-plugin-wiring.mjs",
     "example:install": "cd example-app && bun install --frozen-lockfile",
-    "example:build": "bun run build && cd example-app && bun install --frozen-lockfile && bun run build"
+    "example:build": "bun run build && cd example-app && bun install --frozen-lockfile && bun run build",
+    "check:is-available": "node scripts/check-is-available-result.mjs"
   },
   "devDependencies": {
     "@capacitor/android": "^8.0.0",

--- a/scripts/check-is-available-result.mjs
+++ b/scripts/check-is-available-result.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const pluginDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+const requiredKeys = [
+  "isAvailable",
+  "authenticationStrength",
+  "biometryType",
+  "deviceIsSecure",
+  "strongBiometryIsAvailable",
+];
+
+function read(rel) {
+  return fs.readFileSync(path.join(pluginDir, rel), "utf8");
+}
+
+const errors = [];
+
+const android = read("android/src/main/java/ee/forgr/biometric/NativeBiometric.java");
+const androidBlock = android.match(/private JSObject checkBiometryAvailability\([\s\S]*?^    \}/m);
+if (!androidBlock) {
+  errors.push("Android: missing checkBiometryAvailability()");
+} else {
+  for (const key of requiredKeys) {
+    if (!androidBlock[0].includes(`put("${key}"`)) {
+      errors.push(`Android: checkBiometryAvailability() missing ret.put("${key}")`);
+    }
+  }
+}
+
+const ios = read("ios/Sources/NativeBiometricPlugin/NativeBiometricPlugin.swift");
+const iosBlock = ios.match(/private func checkBiometryAvailability\([\s\S]*?^    \}/m);
+if (!iosBlock) {
+  errors.push("iOS: missing checkBiometryAvailability()");
+} else {
+  for (const key of requiredKeys) {
+    if (!iosBlock[0].includes(`obj["${key}"]`)) {
+      errors.push(`iOS: checkBiometryAvailability() missing obj["${key}"]`);
+    }
+  }
+}
+
+const defs = read("src/definitions.ts");
+const available = defs.match(/export interface AvailableResult \{[\s\S]*?\n\}/);
+if (!available || !available[0].includes("biometryType:")) {
+  errors.push("TypeScript: AvailableResult missing biometryType");
+}
+
+if (errors.length) {
+  console.error("[is-available] FAIL");
+  for (const e of errors) console.error(`- ${e}`);
+  process.exit(1);
+}
+
+console.log("[is-available] OK: isAvailable() native result includes biometryType and related fields");


### PR DESCRIPTION
## Summary
- Ensures `isAvailable()` always exposes `biometryType` (and related `AvailableResult` fields) on iOS/Android via a verify-time contract check.
- On Android, reports `authenticationStrength: WEAK` when only weak biometrics are enrolled while keeping `isAvailable: false` (matches TypeScript/docs for UX icon/text without enabling strong-only `verifyIdentity()`).
- Example app now surfaces biometry type alongside authentication strength when checking availability.

Fixes Cap-go/capacitor-native-biometric#65

## Test plan
- [x] `bun run verify` (includes new `check:is-available` guard)
- [ ] Manual: `NativeBiometric.isAvailable()` on Android device with weak-only face unlock shows non-zero `biometryType` and `authenticationStrength: WEAK`
- [ ] Manual: iOS Touch ID / Face ID device shows correct `biometryType` in example app


Made with [Cursor](https://cursor.com)