### PR TITLE
Skip `requiresCryptoObject` branch for `verifyIdentity` to prevent crash

### DIFF
--- a/android/src/main/java/ee/forgr/biometric/AuthActivity.java
+++ b/android/src/main/java/ee/forgr/biometric/AuthActivity.java
@@ -158,6 +158,8 @@ public class AuthActivity extends AppCompatActivity {
                         handleSetSecureCredentials(result);
                     } else if ("getSecureCredentials".equals(mode) || "getSecureData".equals(mode)) {
                         handleGetSecureCredentials(result);
+                    } else if ("verify".equals(mode)) {
+                        finishActivity();
                     } else if (authenticatorConfig.requiresCryptoObject) {
                         if (!validateCryptoObject(result)) {
                             finishActivity("error", 10, "Biometric security check failed");
@@ -189,7 +191,7 @@ public class AuthActivity extends AppCompatActivity {
             return;
         }
 
-        if (!authenticatorConfig.requiresCryptoObject) {
+        if ("verify".equals(mode) || !authenticatorConfig.requiresCryptoObject) {
             biometricPrompt.authenticate(promptInfo);
             return;
         }


### PR DESCRIPTION
`verifyIdentity()` (with mode="verify") is for identity confirmation and doesn't perform any keystore/crypto operations, but the default configuration sets `requireCryptoObject` to `true`, which causes AuthActivity to create a CryptoObject and pass it to `BiometricPrompt.authenticate()`.

This triggers two bugs:
1. When no `allowedBiometryTypes` are specified, the default config sets `promptAuthenticators` to `BIOMETRIC_STRONG | BIOMETRIC_WEAK` with a `CryptoObject` - Android's `BiometricPrompt` requires `BIOMETRIC_STRONG` only when a `CryptoObject` is present, so this throws `IllegalArgumentException` on every device regardless of hardware.
2. Even if the caller works around the first bug by passing `allowedBiometryTypes=[FINGERPRINT]` to force `BIOMETRIC_STRONG` only, the `onAuthenticationSucceeded` callback runs `validateCryptoObject()` which can fail with "Biometric security check failed" despite successful authentication.

This commit adds `"verify".equals(mode)` guards in AuthActivity to:
 - Skip `CryptoObject` creation in the authenticate path
 - Skip `CryptoObject` validation in the success callback

Secure credential modes are unaffected and continue to use the crypto path as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved biometric verification flow so successful verification completes immediately and consistently.
  * Biometric prompts now use the simpler authentication path for verification, helping avoid unexpected validation issues during sign-in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->