### PR TITLE
fix(android): skip CryptoObject for verifyIdentity to prevent crash

### DIFF
--- a/android/src/main/java/ee/forgr/biometric/AuthActivity.java
+++ b/android/src/main/java/ee/forgr/biometric/AuthActivity.java
@@ -158,6 +158,8 @@ public class AuthActivity extends AppCompatActivity {
                         handleSetSecureCredentials(result);
                     } else if ("getSecureCredentials".equals(mode) || "getSecureData".equals(mode)) {
                         handleGetSecureCredentials(result);
+                    } else if ("verify".equals(mode)) {
+                        finishActivity();
                     } else if (authenticatorConfig.requiresCryptoObject) {
                         if (!validateCryptoObject(result)) {
                             finishActivity("error", 10, "Biometric security check failed");
@@ -189,7 +191,7 @@ public class AuthActivity extends AppCompatActivity {
             return;
         }
 
-        if (!authenticatorConfig.requiresCryptoObject) {
+        if ("verify".equals(mode) || !authenticatorConfig.requiresCryptoObject) {
             biometricPrompt.authenticate(promptInfo);
             return;
         }


### PR DESCRIPTION
## Summary
- Fixes the crash/failure in `verifyIdentity()` on Android when the default authenticator config requires a `CryptoObject` while also allowing `BIOMETRIC_WEAK`.
- Skips `CryptoObject` creation and validation in AuthActivity when `mode` is `verify` (the default for `verifyIdentity()`).
- Secure credential modes keep the crypto path unchanged.
- Based on community PR https://github.com/Cap-go/capacitor-native-biometric/pull/102

## Test plan
- [x] `bun run verify:android` passes locally
- [ ] Call `NativeBiometric.verifyIdentity()` on Android without `allowedBiometryTypes` — prompt should open and succeed without `IllegalArgumentException`
- [ ] Call `verifyIdentity({ allowedBiometryTypes: [BiometryType.FINGERPRINT] })` — should succeed without \"Biometric security check failed\"
- [ ] Confirm `setSecureCredentials` / `getSecureCredentials` with access control still use CryptoObject path


Made with [Cursor](https://cursor.com)