### PR TITLE
fix(android): crash on setCredentials with accessControl (#105)

### DIFF
--- a/android/src/main/java/ee/forgr/biometric/AuthActivity.java
+++ b/android/src/main/java/ee/forgr/biometric/AuthActivity.java
@@ -118,7 +118,15 @@ public class AuthActivity extends AppCompatActivity {
             .setDescription(getIntent().hasExtra("description") ? getIntent().getStringExtra("description") : null);
 
         int[] allowedTypes = getIntent().getIntArrayExtra("allowedBiometryTypes");
-        authenticatorConfig = BiometricAuthenticatorConfig.fromAllowedTypes(allowedTypes);
+        // Crypto-bound secure storage modes must not use STRONG|WEAK: BiometricPrompt rejects
+        // CryptoObject when Class 2 (Weak) authenticators are included.
+        if (isSecureStorageMode()) {
+            authenticatorConfig = BiometricAuthenticatorConfig.ensureCryptoCompatible(
+                BiometricAuthenticatorConfig.fromAllowedTypes(allowedTypes)
+            );
+        } else {
+            authenticatorConfig = BiometricAuthenticatorConfig.fromAllowedTypes(allowedTypes);
+        }
         builder.setAllowedAuthenticators(authenticatorConfig.promptAuthenticators);
 
         if (authenticatorConfig.allowNegativeButton) {

--- a/android/src/main/java/ee/forgr/biometric/BiometricAuthenticatorConfig.java
+++ b/android/src/main/java/ee/forgr/biometric/BiometricAuthenticatorConfig.java
@@ -105,27 +105,28 @@ public final class BiometricAuthenticatorConfig {
      * this must be strong-only — never {@link #defaultBiometric()}.
      */
     static BiometricAuthenticatorConfig defaultForCryptoBoundCredentials() {
-        return new BiometricAuthenticatorConfig(
-            BiometricManager.Authenticators.BIOMETRIC_STRONG,
-            keyAuthStrong(),
-            true,
-            true
-        );
+        return new BiometricAuthenticatorConfig(BiometricManager.Authenticators.BIOMETRIC_STRONG, keyAuthStrong(), true, true);
     }
 
     /**
      * Ensures the config is legal for {@code BiometricPrompt.authenticate(promptInfo, cryptoObject)}.
      * Crypto-based auth only supports Class 3 (Strong) biometrics.
+     * <p>
+     * Note: {@code BIOMETRIC_STRONG} (0x0F) is a subset of {@code BIOMETRIC_WEAK} (0xFF), so "allows
+     * weak" must compare equality to {@code BIOMETRIC_WEAK}, not a non-zero mask.
      */
     static BiometricAuthenticatorConfig ensureCryptoCompatible(BiometricAuthenticatorConfig config) {
         if (config == null) {
             return defaultForCryptoBoundCredentials();
         }
-        boolean hasWeak = (config.promptAuthenticators & BiometricManager.Authenticators.BIOMETRIC_WEAK) != 0;
-        boolean hasDeviceCredential =
-            (config.promptAuthenticators & BiometricManager.Authenticators.DEVICE_CREDENTIAL) != 0;
-        boolean hasStrong = (config.promptAuthenticators & BiometricManager.Authenticators.BIOMETRIC_STRONG) != 0;
-        if (hasWeak || hasDeviceCredential || !hasStrong) {
+        boolean allowsWeak =
+            (config.promptAuthenticators & BiometricManager.Authenticators.BIOMETRIC_WEAK) ==
+            BiometricManager.Authenticators.BIOMETRIC_WEAK;
+        boolean hasDeviceCredential = (config.promptAuthenticators & BiometricManager.Authenticators.DEVICE_CREDENTIAL) != 0;
+        boolean hasStrong =
+            (config.promptAuthenticators & BiometricManager.Authenticators.BIOMETRIC_STRONG) ==
+            BiometricManager.Authenticators.BIOMETRIC_STRONG;
+        if (allowsWeak || hasDeviceCredential || !hasStrong) {
             return defaultForCryptoBoundCredentials();
         }
         return config;

--- a/android/src/main/java/ee/forgr/biometric/BiometricAuthenticatorConfig.java
+++ b/android/src/main/java/ee/forgr/biometric/BiometricAuthenticatorConfig.java
@@ -98,6 +98,39 @@ public final class BiometricAuthenticatorConfig {
         return new BiometricAuthenticatorConfig(PROMPT_BIOMETRIC_ANY, keyAuthAny(), true, true);
     }
 
+    /**
+     * Default for modes that bind a {@code CryptoObject} to {@code BiometricPrompt}
+     * ({@code setSecureCredentials}, {@code getSecureCredentials}, and secure data variants).
+     * AndroidX rejects crypto-based auth when Class 2 (Weak) authenticators are allowed, so
+     * this must be strong-only — never {@link #defaultBiometric()}.
+     */
+    static BiometricAuthenticatorConfig defaultForCryptoBoundCredentials() {
+        return new BiometricAuthenticatorConfig(
+            BiometricManager.Authenticators.BIOMETRIC_STRONG,
+            keyAuthStrong(),
+            true,
+            true
+        );
+    }
+
+    /**
+     * Ensures the config is legal for {@code BiometricPrompt.authenticate(promptInfo, cryptoObject)}.
+     * Crypto-based auth only supports Class 3 (Strong) biometrics.
+     */
+    static BiometricAuthenticatorConfig ensureCryptoCompatible(BiometricAuthenticatorConfig config) {
+        if (config == null) {
+            return defaultForCryptoBoundCredentials();
+        }
+        boolean hasWeak = (config.promptAuthenticators & BiometricManager.Authenticators.BIOMETRIC_WEAK) != 0;
+        boolean hasDeviceCredential =
+            (config.promptAuthenticators & BiometricManager.Authenticators.DEVICE_CREDENTIAL) != 0;
+        boolean hasStrong = (config.promptAuthenticators & BiometricManager.Authenticators.BIOMETRIC_STRONG) != 0;
+        if (hasWeak || hasDeviceCredential || !hasStrong) {
+            return defaultForCryptoBoundCredentials();
+        }
+        return config;
+    }
+
     private static int keyAuthStrong() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             return KEY_AUTH_BIOMETRIC_STRONG;

--- a/android/src/test/java/ee/forgr/biometric/BiometricAuthenticatorConfigTest.java
+++ b/android/src/test/java/ee/forgr/biometric/BiometricAuthenticatorConfigTest.java
@@ -51,4 +51,32 @@ public class BiometricAuthenticatorConfigTest {
 
         assertEquals(BiometricManager.Authenticators.BIOMETRIC_STRONG, config.promptAuthenticators);
     }
+
+    @Test
+    public void cryptoBoundCredentials_defaultUsesStrongOnly() {
+        BiometricAuthenticatorConfig config = BiometricAuthenticatorConfig.defaultForCryptoBoundCredentials();
+
+        assertEquals(BiometricManager.Authenticators.BIOMETRIC_STRONG, config.promptAuthenticators);
+        assertTrue(config.allowNegativeButton);
+        assertTrue(config.requiresCryptoObject);
+        assertEquals(0, config.promptAuthenticators & BiometricManager.Authenticators.BIOMETRIC_WEAK);
+    }
+
+    @Test
+    public void ensureCryptoCompatible_upgradesWeakDefaultToStrong() {
+        BiometricAuthenticatorConfig weakDefault = BiometricAuthenticatorConfig.fromAllowedTypes(null);
+        BiometricAuthenticatorConfig config = BiometricAuthenticatorConfig.ensureCryptoCompatible(weakDefault);
+
+        assertEquals(BiometricManager.Authenticators.BIOMETRIC_STRONG, config.promptAuthenticators);
+        assertEquals(0, config.promptAuthenticators & BiometricManager.Authenticators.BIOMETRIC_WEAK);
+    }
+
+    @Test
+    public void ensureCryptoCompatible_keepsFingerprintStrong() {
+        BiometricAuthenticatorConfig strong = BiometricAuthenticatorConfig.fromAllowedTypes(new int[] { 3 });
+        BiometricAuthenticatorConfig config = BiometricAuthenticatorConfig.ensureCryptoCompatible(strong);
+
+        assertEquals(BiometricManager.Authenticators.BIOMETRIC_STRONG, config.promptAuthenticators);
+        assertTrue(config.requiresCryptoObject);
+    }
 }

--- a/android/src/test/java/ee/forgr/biometric/BiometricAuthenticatorConfigTest.java
+++ b/android/src/test/java/ee/forgr/biometric/BiometricAuthenticatorConfigTest.java
@@ -59,7 +59,9 @@ public class BiometricAuthenticatorConfigTest {
         assertEquals(BiometricManager.Authenticators.BIOMETRIC_STRONG, config.promptAuthenticators);
         assertTrue(config.allowNegativeButton);
         assertTrue(config.requiresCryptoObject);
-        assertEquals(0, config.promptAuthenticators & BiometricManager.Authenticators.BIOMETRIC_WEAK);
+        assertTrue(
+            (config.promptAuthenticators & BiometricManager.Authenticators.BIOMETRIC_WEAK) != BiometricManager.Authenticators.BIOMETRIC_WEAK
+        );
     }
 
     @Test
@@ -67,8 +69,11 @@ public class BiometricAuthenticatorConfigTest {
         BiometricAuthenticatorConfig weakDefault = BiometricAuthenticatorConfig.fromAllowedTypes(null);
         BiometricAuthenticatorConfig config = BiometricAuthenticatorConfig.ensureCryptoCompatible(weakDefault);
 
+        assertEquals(BiometricAuthenticatorConfig.PROMPT_BIOMETRIC_ANY, weakDefault.promptAuthenticators);
         assertEquals(BiometricManager.Authenticators.BIOMETRIC_STRONG, config.promptAuthenticators);
-        assertEquals(0, config.promptAuthenticators & BiometricManager.Authenticators.BIOMETRIC_WEAK);
+        assertTrue(
+            (config.promptAuthenticators & BiometricManager.Authenticators.BIOMETRIC_WEAK) != BiometricManager.Authenticators.BIOMETRIC_WEAK
+        );
     }
 
     @Test


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Fix Android crash when calling `setCredentials()` / `getSecureCredentials()` with `accessControl` set (`BIOMETRY_ANY` / `BIOMETRY_CURRENT_SET`).
- Crypto-bound secure storage modes now use `BIOMETRIC_STRONG` only instead of falling back to `BIOMETRIC_STRONG | BIOMETRIC_WEAK`.

## Why
- `AuthActivity` resolved authenticators via `fromAllowedTypes(null)` → `defaultBiometric()` (`STRONG | WEAK`) while still passing a `CryptoObject`.
- AndroidX `BiometricPrompt.authenticate(promptInfo, cryptoObject)` rejects Class 2 (Weak) authenticators unconditionally, so the app crashed before any prompt was shown (issue #105).

## How
- Added `defaultForCryptoBoundCredentials()` (strong-only) and `ensureCryptoCompatible()` in `BiometricAuthenticatorConfig`.
- `AuthActivity` applies crypto-compatible authenticators for all secure storage modes (`setSecureCredentials`, `getSecureCredentials`, secure data variants).
- Weak detection uses equality to `BIOMETRIC_WEAK` because `BIOMETRIC_STRONG` is a bit subset of `BIOMETRIC_WEAK`.
- `verifyIdentity()` path unchanged.
- Unit tests cover the strong-only default and weak→strong coercion.

## Testing
- `bun run verify:android` (clean build + unit tests) — passed
- `bun run fmt` / `bun run lint` — passed
- Unit tests for `BiometricAuthenticatorConfig` including crypto-compat cases

## Not Tested
- Physical Android device biometric prompt for `setCredentials({ accessControl })` / `getSecureCredentials()`
- iOS (unaffected)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fcb03-f63f-78da-ab24-e22f2f70d89e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fcb03-f63f-78da-ab24-e22f2f70d89e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-native-biometric/pull/106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

