### PR TITLE
fix(android): legacy credential fallback never runs when Keystore reports malformed GCM input

### DIFF
--- a/android/src/main/java/ee/forgr/biometric/NativeBiometric.java
+++ b/android/src/main/java/ee/forgr/biometric/NativeBiometric.java
@@ -41,7 +41,6 @@ import java.security.UnrecoverableEntryException;
 import java.security.cert.CertificateException;
 import java.util.ArrayList;
 import java.util.Objects;
-import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.CipherInputStream;
 import javax.crypto.CipherOutputStream;
@@ -76,6 +75,8 @@ public class NativeBiometric extends Plugin {
     private static final String RSA_MODE = "RSA/ECB/PKCS1Padding";
     private static final String AES_MODE = "AES/ECB/PKCS7Padding";
     private static final int GCM_IV_LENGTH = 12;
+    private static final int GCM_TAG_LENGTH_BYTES = 16;
+    private static final int MIN_NEW_FORMAT_LENGTH = GCM_IV_LENGTH + GCM_TAG_LENGTH_BYTES;
     private static final String ENCRYPTED_KEY = "NativeBiometricKey";
     private static final String NATIVE_BIOMETRIC_SHARED_PREFERENCES = "NativeBiometricSharedPreferences";
     private static final String DATA_KEY_PREFIX = "data_";
@@ -710,11 +711,13 @@ public class NativeBiometric extends Plugin {
     private String decryptString(String stringToDecrypt, String KEY_ALIAS) throws GeneralSecurityException, IOException {
         byte[] combined = Base64.decode(stringToDecrypt, Base64.DEFAULT);
 
-        // Try new format first (IV prepended to ciphertext)
-        // New format: 12-byte IV + ciphertext (plaintext + 16-byte GCM auth tag)
-        // We check for > GCM_IV_LENGTH to ensure there's at least some ciphertext beyond just the IV
-        // The cipher's doFinal() will validate the auth tag and fail if data is malformed
-        if (combined.length >= GCM_IV_LENGTH + 1) {
+        GeneralSecurityException newFormatFailure = null;
+
+        // New format is IV + ciphertext + 16-byte GCM tag, so anything shorter than
+        // MIN_NEW_FORMAT_LENGTH cannot be new format and must be tried as legacy only.
+        // Feeding a short legacy blob into the new-format path leaves fewer than 16
+        // bytes after stripping the IV, which Keystore rejects as malformed input.
+        if (combined.length >= MIN_NEW_FORMAT_LENGTH) {
             try {
                 // Extract IV from the beginning of the data
                 byte[] iv = new byte[GCM_IV_LENGTH];
@@ -726,23 +729,29 @@ public class NativeBiometric extends Plugin {
                 cipher.init(Cipher.DECRYPT_MODE, getKey(KEY_ALIAS), new GCMParameterSpec(128, iv));
                 byte[] decryptedData = cipher.doFinal(encryptedData);
                 return new String(decryptedData, StandardCharsets.UTF_8);
-            } catch (BadPaddingException e) {
-                // Authentication tag verification failed (AEADBadTagException) or padding error
-                // BadPaddingException is the parent class of AEADBadTagException
-                // Likely means data was encrypted with legacy format - fall through to legacy decryption
             } catch (GeneralSecurityException e) {
-                // Other security exceptions should not be masked - rethrow
-                throw e;
+                // A failure here usually just means the blob is legacy format. Keystore
+                // implementations disagree on which exception a malformed GCM input maps
+                // to (BadPadding on some devices, IllegalBlockSize on others), so the
+                // exception type must not gate the legacy fallback.
+                newFormatFailure = e;
             }
         }
 
         // Fallback to legacy format (FIXED_IV - all zeros)
         // This branch handles credentials encrypted with the old vulnerable method
-        byte[] LEGACY_FIXED_IV = new byte[12]; // All zeros by default
-        Cipher cipher = Cipher.getInstance(TRANSFORMATION);
-        cipher.init(Cipher.DECRYPT_MODE, getKey(KEY_ALIAS), new GCMParameterSpec(128, LEGACY_FIXED_IV));
-        byte[] decryptedData = cipher.doFinal(combined);
-        return new String(decryptedData, StandardCharsets.UTF_8);
+        try {
+            byte[] LEGACY_FIXED_IV = new byte[12]; // All zeros by default
+            Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            cipher.init(Cipher.DECRYPT_MODE, getKey(KEY_ALIAS), new GCMParameterSpec(128, LEGACY_FIXED_IV));
+            byte[] decryptedData = cipher.doFinal(combined);
+            return new String(decryptedData, StandardCharsets.UTF_8);
+        } catch (GeneralSecurityException | IOException e) {
+            if (newFormatFailure != null) {
+                e.addSuppressed(newFormatFailure);
+            }
+            throw e;
+        }
     }
 
     @SuppressLint("NewAPI") // API level is already checked

--- a/android/src/main/java/ee/forgr/biometric/NativeBiometric.java
+++ b/android/src/main/java/ee/forgr/biometric/NativeBiometric.java
@@ -711,6 +711,10 @@ public class NativeBiometric extends Plugin {
     private String decryptString(String stringToDecrypt, String KEY_ALIAS) throws GeneralSecurityException, IOException {
         byte[] combined = Base64.decode(stringToDecrypt, Base64.DEFAULT);
 
+        // Resolve the key once, outside format detection: a keystore failure is a
+        // real error and must not be mistaken for a format mismatch.
+        Key key = getKey(KEY_ALIAS);
+
         GeneralSecurityException newFormatFailure = null;
 
         // New format is IV + ciphertext + 16-byte GCM tag, so anything shorter than
@@ -726,7 +730,7 @@ public class NativeBiometric extends Plugin {
                 System.arraycopy(combined, GCM_IV_LENGTH, encryptedData, 0, encryptedData.length);
 
                 Cipher cipher = Cipher.getInstance(TRANSFORMATION);
-                cipher.init(Cipher.DECRYPT_MODE, getKey(KEY_ALIAS), new GCMParameterSpec(128, iv));
+                cipher.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(128, iv));
                 byte[] decryptedData = cipher.doFinal(encryptedData);
                 return new String(decryptedData, StandardCharsets.UTF_8);
             } catch (GeneralSecurityException e) {
@@ -743,10 +747,10 @@ public class NativeBiometric extends Plugin {
         try {
             byte[] LEGACY_FIXED_IV = new byte[12]; // All zeros by default
             Cipher cipher = Cipher.getInstance(TRANSFORMATION);
-            cipher.init(Cipher.DECRYPT_MODE, getKey(KEY_ALIAS), new GCMParameterSpec(128, LEGACY_FIXED_IV));
+            cipher.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(128, LEGACY_FIXED_IV));
             byte[] decryptedData = cipher.doFinal(combined);
             return new String(decryptedData, StandardCharsets.UTF_8);
-        } catch (GeneralSecurityException | IOException e) {
+        } catch (GeneralSecurityException e) {
             if (newFormatFailure != null) {
                 e.addSuppressed(newFormatFailure);
             }


### PR DESCRIPTION
### Summary

The legacy-format fallback added in 8.2.0 does not run on a large share of Android devices, so users upgrading from a pre-8.2.0 version permanently fail to read their stored credentials with `Failed to get credentials`.

Two separate defects in `decryptString` combine to cause this:

1. **The new-format length guard is too permissive.** A new-format blob is `12-byte IV || ciphertext || 16-byte GCM tag`, so its minimum length is 28 bytes. The current guard is `combined.length >= GCM_IV_LENGTH + 1` (13 bytes). Legacy blobs between 13 and 27 bytes therefore enter the new-format branch, where stripping 12 bytes leaves fewer than the 16 bytes a GCM tag requires. Keystore then rejects the input as malformed rather than as an authentication failure.

2. **The fallback is gated on the exception type.** It only runs on `BadPaddingException`; every other `GeneralSecurityException` is rethrown. This assumes that malformed GCM input always surfaces as `BadPaddingException`, which is not true across Keystore implementations — see the evidence below.

Result: for any credential whose plaintext is shorter than 12 bytes, the fallback is skipped entirely on affected devices and the legacy data becomes unreadable.

### Evidence

Tested on three Android 16 (SDK 36) devices, StrongBox-backed keys, same account, same app build, same stored data. Instrumented `decryptString` to log the blob length and the full exception chain.

Two credentials are stored under the same alias:

- username — 52-byte legacy blob (36-byte plaintext + 16-byte tag)
- password — 25-byte legacy blob (9-byte plaintext + 16-byte tag)

**Control — the 52-byte blob. All three devices behave identically:**

```
javax.crypto.AEADBadTagException
  <- android.security.KeyStoreException: Signature/MAC verification failed
     (internal Keystore code: -30, Error::Km(r#VERIFICATION_FAILED))
  -> caught as BadPaddingException -> legacy fallback -> SUCCESS
```

This is the intended path: the blob is long enough to reach `doFinal`, the tag check fails, and the fallback recovers it.

**Divergence — the 25-byte blob. Only 13 bytes remain after the IV is stripped, which is less than the 16-byte tag:**

| Device | Keystore error | Java exception | Fallback runs | Result |
|---|---|---|---|---|
| Samsung | `-9 UNSUPPORTED_MAC_LENGTH` | `IllegalBlockSizeException` | no | **fails** |
| Xiaomi | `-21 INVALID_INPUT_LENGTH` | `IllegalBlockSizeException` | no | **fails** |
| Pixel | `-38 INVALID_ARGUMENT` | `BadPaddingException` | yes | succeeds |

Three KeyMint implementations classify the *same malformed input* three different ways. Only the Pixel mapping happens to land on the branch the fallback listens for. Full chains:

```
Samsung
javax.crypto.IllegalBlockSizeException
  <- android.security.KeyStoreException: Unsupported MAC or authentication tag length
     (internal Keystore code: -9, Error::Km(r#UNSUPPORTED_MAC_LENGTH))

Xiaomi
javax.crypto.IllegalBlockSizeException
  <- android.security.KeyStoreException: Invalid input length
     (internal Keystore code: -21, Error::Km(r#INVALID_INPUT_LENGTH))

Pixel
javax.crypto.BadPaddingException
  <- android.security.KeyStoreException: Invalid argument
     (internal Keystore code: -38, Error::Km(r#INVALID_ARGUMENT))
```

The control blob rules out device-level differences in key material, StrongBox behaviour, or storage: the only variable is blob length.

### Fix

**1. Correct the length guard** so short legacy blobs never enter the new-format branch:

```java
private static final int GCM_TAG_LENGTH_BYTES = 16;
private static final int MIN_NEW_FORMAT_LENGTH = GCM_IV_LENGTH + GCM_TAG_LENGTH_BYTES;
...
if (combined.length >= MIN_NEW_FORMAT_LENGTH) {
```

This alone makes the reported case deterministic on every device, with no dependency on exception types.

**2. Stop gating the fallback on the exception type.** Blobs of 28 bytes or more that are actually legacy still reach the new-format branch and still rely on it failing, so the fallback must accept any `GeneralSecurityException`. The new-format failure is attached via `addSuppressed` so it is not lost when both formats fail.

**3. Resolve the key outside the format-detection block.** Widening the catch in step 2 would otherwise swallow genuine keystore faults, because `getKey()` was called inside the `try` and throws `GeneralSecurityException` subtypes of its own (`KeyStoreException`, or `UnrecoverableEntryException` after a biometric re-enrolment invalidates the key). Those are real errors, not format mismatches, and must propagate. Hoisting the lookup keeps the catch broad — the exception type still never gates the fallback — while restricting the `try` to the attempt itself:

```java
byte[] combined = Base64.decode(stringToDecrypt, Base64.DEFAULT);

// Resolve the key once, outside format detection: a keystore failure is a
// real error and must not be mistaken for a format mismatch.
Key key = getKey(KEY_ALIAS);

GeneralSecurityException newFormatFailure = null;

if (combined.length >= MIN_NEW_FORMAT_LENGTH) {
    try {
        ...
        cipher.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(128, iv));
        ...
        return new String(decryptedData, StandardCharsets.UTF_8);
    } catch (GeneralSecurityException e) {
        newFormatFailure = e;
    }
}

try {
    ...legacy all-zero IV, same `key`...
    return new String(decryptedData, StandardCharsets.UTF_8);
} catch (GeneralSecurityException e) {
    if (newFormatFailure != null) {
        e.addSuppressed(newFormatFailure);
    }
    throw e;
}
```

This also halves the number of keystore lookups per read, which matters for the concern raised in the last section: the current code calls `getKey()` twice on every legacy read, and `getKey()` regenerates the key whenever `getEntry()` returns null. One lookup means one opportunity to regenerate instead of two.

`| IOException` has to come off the legacy catch: with `getKey()` hoisted out, nothing left inside that block can throw it, and Java rejects catching a checked exception the `try` cannot raise. The method signature keeps `throws IOException` because the hoisted `getKey()` still declares it.

### Compatibility

No change to the storage format, the write path, or key handling. Blobs written by any version remain readable by any version.

The only behavioural change on the data path is that cases which previously threw now attempt the legacy format once more, so a failure can become a success but never the reverse. Genuinely corrupt data still throws, and now carries both failure reasons.

Keystore faults change shape slightly: they now surface before either format is attempted, rather than after the new-format attempt. The exception that reaches the caller is the same one, and it is no longer at risk of being wrapped or masked by a subsequent legacy attempt.

### Verification

The patch was applied to 8.6.2 and the same upgrade path re-run on the two devices that previously failed — same accounts, same stored blobs, same short password.

**Samsung, first launch after upgrading over the old build:**

```
decryptString: combinedLength=25 triesNewFormat=false bytesAfterIv=13
  -> legacy-format decrypt SUCCEEDED
```

The 25-byte blob no longer enters the new-format branch at all, so nothing on this path raises an exception. Before the patch the same blob produced `IllegalBlockSizeException` (`-9 UNSUPPORTED_MAC_LENGTH`) and the fallback was skipped.

**Samsung, subsequent cold start**, after the app had re-encrypted the credential in the new format:

```
decryptString: combinedLength=37 triesNewFormat=true bytesAfterIv=25
  -> new-format decrypt SUCCEEDED
```

No `falling back to legacy` anywhere in the log, confirming the blob is genuinely stored in the new format rather than being rescued by the fallback on every read.

**Xiaomi behaves identically**, same log signature. The two devices reported different Keystore errors before the patch (`-9` vs `-21`) and behave the same after it — which is the point: the corrected path decides on blob length and never consults the exception type.

The 52-byte control blob still takes the new-format-fails-then-falls-back path on both devices, unchanged.

Pixel could not be re-tested against a short legacy blob: it had already migrated to the new format during the original investigation, precisely because its `BadPaddingException` mapping happened to hit the existing fallback. Restoring legacy data there requires downgrading to 7.x first.

`NativeBiometric.java` is byte-identical between 8.6.2 and 8.6.3, so this verification carries over to the current release unchanged.

**Fix 3 re-verified on Xiaomi** against the same pre-8.2.0 credential pair. Both blobs now resolve the key exactly once, and the fallback still works:

```
decryptString: combinedLength=52 triesNewFormat=true bytesAfterIv=40
  getKey: reusing EXISTING keystore entry            <- once, before either attempt
  new-format decrypt failed, falling back to legacy
    javax.crypto.AEADBadTagException
      <- KeyStoreException: Signature/MAC verification failed (-30 VERIFICATION_FAILED)
  legacy-format decrypt SUCCEEDED                    <- no second getKey

decryptString: combinedLength=25 triesNewFormat=false bytesAfterIv=13
  getKey: reusing EXISTING keystore entry            <- once
  legacy-format decrypt SUCCEEDED                    <- no exception raised at all
```

Before the hoist, a second `getKey` appeared between `falling back to legacy` and `legacy-format decrypt SUCCEEDED`. Its absence is the direct evidence that the read path went from two keystore lookups to one.

The subsequent re-encryption emits `combinedLength=64` and `combinedLength=37`, confirming both credentials were rewritten in the new format.

### Reproduction

1. Install a build using 7.x, call `setCredentials` with a password shorter than 12 bytes.
2. Upgrade the app to 8.2.0 or later without clearing app data.
3. Call `getCredentials`.

Fails on Samsung and Xiaomi; succeeds on Pixel.

### Related: `getKey()` regenerates keys on the read path

Not addressed in this PR, but worth flagging as it can turn a transient failure into permanent data loss.

`getKey()` silently calls `generateKey()` whenever `keyStore.getEntry()` returns null, and `decryptString` calls `getKey()` on every read. A single transient Keystore miss during a read therefore mints a fresh key, after which every previously stored credential becomes undecryptable in **both** formats — with no error surfaced at the moment the damage is done.

Key creation on a decrypt path is a write disguised as a read. The read path should fail loudly instead, leaving the caller to decide whether to re-enrol.

This PR narrows the exposure without fixing the root cause: hoisting the lookup (fix 3) takes `decryptString` from two `getKey()` calls per read down to one, so a legacy read now has one chance to trip the regeneration rather than two. Making `getKey()` non-mutating on the read path is still worth doing separately.
