### PR TITLE
fix(android): crash on setCredentials with accessControl (Fixes #105)

### DIFF
--- a/android/src/test/java/ee/forgr/biometric/BiometricAuthenticatorConfigTest.java
+++ b/android/src/test/java/ee/forgr/biometric/BiometricAuthenticatorConfigTest.java
@@ -84,4 +84,13 @@ public class BiometricAuthenticatorConfigTest {
         assertEquals(BiometricManager.Authenticators.BIOMETRIC_STRONG, config.promptAuthenticators);
         assertTrue(config.requiresCryptoObject);
     }
+
+    @Test
+    public void ensureCryptoCompatible_upgradesFaceAuthenticationToStrong() {
+        BiometricAuthenticatorConfig face = BiometricAuthenticatorConfig.fromAllowedTypes(new int[] { 4 });
+        BiometricAuthenticatorConfig config = BiometricAuthenticatorConfig.ensureCryptoCompatible(face);
+
+        assertEquals(BiometricAuthenticatorConfig.PROMPT_BIOMETRIC_ANY, face.promptAuthenticators);
+        assertEquals(BiometricManager.Authenticators.BIOMETRIC_STRONG, config.promptAuthenticators);
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Confirm and document the fix for Android crash when calling `setCredentials()` / `getSecureCredentials()` with `accessControl` (`BIOMETRY_ANY` / `BIOMETRY_CURRENT_SET`).
- Add a regression unit test for the `FACE_AUTHENTICATION` → `PROMPT_BIOMETRIC_ANY` coercion path that previously triggered the crash.

## Why
- `AuthActivity` resolved authenticators via `fromAllowedTypes(null)` → `defaultBiometric()` (`BIOMETRIC_STRONG | BIOMETRIC_WEAK`) while still passing a `CryptoObject`.
- AndroidX `BiometricPrompt.authenticate(promptInfo, cryptoObject)` rejects Class 2 (Weak) authenticators unconditionally, crashing before any prompt (#105).

## How
The core fix (already on `main` since #106, released in **8.6.3**):
- Added `defaultForCryptoBoundCredentials()` (strong-only) and `ensureCryptoCompatible()` in `BiometricAuthenticatorConfig`.
- `AuthActivity` applies crypto-compatible authenticators for all secure storage modes (`setSecureCredentials`, `getSecureCredentials`, secure data variants).
- Weak detection uses equality to `BIOMETRIC_WEAK` because `BIOMETRIC_STRONG` is a bit subset of `BIOMETRIC_WEAK`.
- `verifyIdentity()` path unchanged (no `CryptoObject`).

This PR adds a regression test (`ensureCryptoCompatible_upgradesFaceAuthenticationToStrong`) covering the face-unlock authenticator path.

Fixes #105

## Testing
- `bun run verify:android` — passed (clean build + unit tests)
- `bun run fmt` — passed
- Unit tests for `BiometricAuthenticatorConfig` including crypto-compat cases

## Not Tested
- Physical Android device biometric prompt for `setCredentials({ accessControl })` / `getSecureCredentials()`
- iOS (unaffected)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-690fbb36-db89-4f56-9984-83ff6f032f51?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-690fbb36-db89-4f56-9984-83ff6f032f51&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-native-biometric/pr/109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789145102&installation_model_id=430928&pr_number=109&repository=Cap-go%2Fcapacitor-native-biometric&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-native-biometric%2Fpull%2F109&signature=48d489563ff77acf92aa930e9a49d8e02e80bad851db92dd0808ac2fd7afb81f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-native-biometric/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

