### PR TITLE
fix(android): map KEY_AUTH_* flags to KeyProperties.AUTH_* for Keystore keys

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - renovate/**
+      - fix/android-key-auth-type-mapping
   pull_request:
     branches: [ main ]
   workflow_call:  # Allow this workflow to be called by other workflows

--- a/android/src/main/java/ee/forgr/biometric/AuthActivity.java
+++ b/android/src/main/java/ee/forgr/biometric/AuthActivity.java
@@ -312,7 +312,7 @@ public class AuthActivity extends AppCompatActivity {
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             int authTypes = keyAuthTypes > 0 ? keyAuthTypes : defaultKeyAuthTypes();
-            builder.setUserAuthenticationParameters(0, authTypes);
+            builder.setUserAuthenticationParameters(0, BiometricAuthenticatorConfig.toKeyPropertiesAuthTypes(authTypes));
         } else {
             // Use -1 for per-operation authentication, required for BiometricPrompt CryptoObject binding.
             // A positive value creates a time-based key that throws UserNotAuthenticatedException
@@ -415,7 +415,10 @@ public class AuthActivity extends AppCompatActivity {
             if (authTypes == 0) {
                 authTypes = defaultKeyAuthTypes();
             }
-            builder.setUserAuthenticationParameters(Math.max(0, authValidityDuration), authTypes);
+            builder.setUserAuthenticationParameters(
+                Math.max(0, authValidityDuration),
+                BiometricAuthenticatorConfig.toKeyPropertiesAuthTypes(authTypes)
+            );
         } else if (authValidityDuration > 0) {
             builder.setUserAuthenticationValidityDurationSeconds(authValidityDuration);
         } else {

--- a/android/src/main/java/ee/forgr/biometric/AuthActivity.java
+++ b/android/src/main/java/ee/forgr/biometric/AuthActivity.java
@@ -42,6 +42,7 @@ public class AuthActivity extends AppCompatActivity {
     private static final String SHARED_PREFS_NAME = "NativeBiometricSharedPreferences";
     private static final String SECURE_VALIDITY_SUFFIX = "_validity";
     private static final String SECURE_AUTH_SCHEME_SUFFIX = "_auth_scheme";
+    private static final String SECURE_ACCESS_CONTROL_SUFFIX = "_access_control";
 
     private BiometricPrompt biometricPrompt;
     private Cipher authCipher;
@@ -271,7 +272,7 @@ public class AuthActivity extends AppCompatActivity {
         }
         SharedPreferences prefs = getSharedPreferences(SHARED_PREFS_NAME, MODE_PRIVATE);
         int storedScheme = prefs.getInt(AUTH_KEY_AUTH_TYPES_SCHEME, 0);
-        if (keyStore.containsAlias(AUTH_KEY_ALIAS) && storedScheme < BiometricAuthenticatorConfig.KEY_AUTH_TYPES_SCHEME_VERSION) {
+        if (keyStore.containsAlias(AUTH_KEY_ALIAS) && shouldRegenerateAuthKey(storedScheme)) {
             keyStore.deleteEntry(AUTH_KEY_ALIAS);
         }
         int expectedAuthTypes = getAuthKeyTypes();
@@ -374,10 +375,9 @@ public class AuthActivity extends AppCompatActivity {
 
         if (ks.containsAlias(alias)) {
             int storedScheme = getStoredCredentialAuthScheme(server);
-            if (storedScheme < BiometricAuthenticatorConfig.KEY_AUTH_TYPES_SCHEME_VERSION) {
-                // Pre-mapping keys used plugin flags as KeyProperties values; ciphertext cannot be
-                // migrated in place, so drop the legacy key and stored payload and let the caller
-                // re-enroll via setSecureCredentials / setSecureData.
+            if (storedScheme > 0 && storedScheme < BiometricAuthenticatorConfig.KEY_AUTH_TYPES_SCHEME_VERSION) {
+                // Only keys explicitly tagged with an outdated scheme are recovered here. Missing
+                // metadata (0) may be a pre-API-30 key that never used setUserAuthenticationParameters.
                 recoverCredentialKeyFromLegacyScheme(server, ks);
             } else if (getStoredAuthValidityDuration(server) != authValidityDuration) {
                 // If the caller asked for a different auth model than the one the existing key was
@@ -385,12 +385,16 @@ public class AuthActivity extends AppCompatActivity {
                 // regenerated so the new setUserAuthenticationParameters() take effect — Keystore
                 // does not allow changing these parameters on an existing key.
                 ks.deleteEntry(alias);
+            } else if (accessControl > 0 && getStoredAccessControl(server) != accessControl) {
+                ks.deleteEntry(alias);
+                getSharedPreferences(SHARED_PREFS_NAME, MODE_PRIVATE).edit().remove("secure_" + server).apply();
             } else {
                 return (SecretKey) ks.getKey(alias, null);
             }
         }
 
-        boolean invalidatedByEnrollment = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && accessControl == 1;
+        int effectiveAccessControl = resolveAccessControl(server, accessControl);
+        boolean invalidatedByEnrollment = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && effectiveAccessControl == 1;
         SecretKey key;
         try {
             key = buildCredentialKey(alias, invalidatedByEnrollment, authValidityDuration);
@@ -411,7 +415,27 @@ public class AuthActivity extends AppCompatActivity {
         }
         storeAuthValidityDuration(server, authValidityDuration);
         storeCredentialAuthScheme(server, BiometricAuthenticatorConfig.KEY_AUTH_TYPES_SCHEME_VERSION);
+        if (accessControl > 0) {
+            storeAccessControl(server, accessControl);
+        }
         return key;
+    }
+
+    private boolean shouldRegenerateAuthKey(int storedScheme) {
+        if (storedScheme > 0 && storedScheme < BiometricAuthenticatorConfig.KEY_AUTH_TYPES_SCHEME_VERSION) {
+            return true;
+        }
+        // Missing metadata on API 30+ may mean the plugin KEY_AUTH_* flags were passed straight
+        // through to setUserAuthenticationParameters. Pre-API-30 keys also lack metadata but used
+        // setUserAuthenticationValidityDurationSeconds instead, so only regenerate on API 30+.
+        return storedScheme == 0 && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R;
+    }
+
+    private int resolveAccessControl(String server, int accessControl) {
+        if (accessControl > 0) {
+            return accessControl;
+        }
+        return getStoredAccessControl(server);
     }
 
     private void recoverCredentialKeyFromLegacyScheme(String server, KeyStore keyStore) throws GeneralSecurityException, IOException {
@@ -423,6 +447,7 @@ public class AuthActivity extends AppCompatActivity {
         editor.remove("secure_" + server);
         editor.remove("secure_" + server + SECURE_VALIDITY_SUFFIX);
         editor.remove("secure_" + server + SECURE_AUTH_SCHEME_SUFFIX);
+        editor.remove("secure_" + server + SECURE_ACCESS_CONTROL_SUFFIX);
         editor.apply();
     }
 
@@ -775,10 +800,21 @@ public class AuthActivity extends AppCompatActivity {
         return getSharedPreferences(SHARED_PREFS_NAME, MODE_PRIVATE).getInt("secure_" + server + SECURE_AUTH_SCHEME_SUFFIX, 0);
     }
 
+    private int getStoredAccessControl(String server) {
+        return getSharedPreferences(SHARED_PREFS_NAME, MODE_PRIVATE).getInt("secure_" + server + SECURE_ACCESS_CONTROL_SUFFIX, 0);
+    }
+
     private void storeCredentialAuthScheme(String server, int schemeVersion) {
         getSharedPreferences(SHARED_PREFS_NAME, MODE_PRIVATE)
             .edit()
             .putInt("secure_" + server + SECURE_AUTH_SCHEME_SUFFIX, schemeVersion)
+            .apply();
+    }
+
+    private void storeAccessControl(String server, int accessControl) {
+        getSharedPreferences(SHARED_PREFS_NAME, MODE_PRIVATE)
+            .edit()
+            .putInt("secure_" + server + SECURE_ACCESS_CONTROL_SUFFIX, accessControl)
             .apply();
     }
 }

--- a/android/src/main/java/ee/forgr/biometric/AuthActivity.java
+++ b/android/src/main/java/ee/forgr/biometric/AuthActivity.java
@@ -384,12 +384,14 @@ public class AuthActivity extends AppCompatActivity {
                 keystoreAuthType = info.authType;
                 validityDurationSeconds = info.validityDurationSeconds;
             }
-            if (BiometricAuthenticatorConfig.shouldRecoverLegacyCredentialKey(
-                storedScheme,
-                Build.VERSION.SDK_INT,
-                keystoreAuthType,
-                validityDurationSeconds
-            )) {
+            if (
+                BiometricAuthenticatorConfig.shouldRecoverLegacyCredentialKey(
+                    storedScheme,
+                    Build.VERSION.SDK_INT,
+                    keystoreAuthType,
+                    validityDurationSeconds
+                )
+            ) {
                 recoverCredentialKeyFromLegacyScheme(server, ks);
             } else if (getStoredAuthValidityDuration(server) != authValidityDuration) {
                 // If the caller asked for a different auth model than the one the existing key was
@@ -451,6 +453,7 @@ public class AuthActivity extends AppCompatActivity {
     }
 
     private static final class CredentialKeyAuthInfo {
+
         final Integer authType;
         final Integer validityDurationSeconds;
 

--- a/android/src/main/java/ee/forgr/biometric/AuthActivity.java
+++ b/android/src/main/java/ee/forgr/biometric/AuthActivity.java
@@ -41,6 +41,7 @@ public class AuthActivity extends AppCompatActivity {
     private static final int CREDENTIAL_GCM_IV_LENGTH = 12;
     private static final String SHARED_PREFS_NAME = "NativeBiometricSharedPreferences";
     private static final String SECURE_VALIDITY_SUFFIX = "_validity";
+    private static final String SECURE_AUTH_SCHEME_SUFFIX = "_auth_scheme";
 
     private BiometricPrompt biometricPrompt;
     private Cipher authCipher;
@@ -50,6 +51,7 @@ public class AuthActivity extends AppCompatActivity {
     private int authValidityDuration;
     private BiometricAuthenticatorConfig authenticatorConfig;
     private static final String AUTH_KEY_AUTH_TYPES = "auth_key_auth_types";
+    private static final String AUTH_KEY_AUTH_TYPES_SCHEME = "auth_key_auth_types_scheme";
 
     // Mirrors KeyProperties auth-type flags when older compile stubs omit symbols.
     private static final int KEY_AUTH_BIOMETRIC_STRONG = 1;
@@ -267,14 +269,20 @@ public class AuthActivity extends AppCompatActivity {
         } catch (CertificateException e) {
             throw new GeneralSecurityException("Failed to load AndroidKeyStore", e);
         }
+        SharedPreferences prefs = getSharedPreferences(SHARED_PREFS_NAME, MODE_PRIVATE);
+        int storedScheme = prefs.getInt(AUTH_KEY_AUTH_TYPES_SCHEME, 0);
+        if (keyStore.containsAlias(AUTH_KEY_ALIAS) && storedScheme < BiometricAuthenticatorConfig.KEY_AUTH_TYPES_SCHEME_VERSION) {
+            keyStore.deleteEntry(AUTH_KEY_ALIAS);
+        }
         int expectedAuthTypes = getAuthKeyTypes();
-        int storedAuthTypes = getSharedPreferences(SHARED_PREFS_NAME, MODE_PRIVATE).getInt(AUTH_KEY_AUTH_TYPES, -1);
+        int storedAuthTypes = prefs.getInt(AUTH_KEY_AUTH_TYPES, -1);
         if (keyStore.containsAlias(AUTH_KEY_ALIAS) && storedAuthTypes != expectedAuthTypes) {
             keyStore.deleteEntry(AUTH_KEY_ALIAS);
         }
         if (!keyStore.containsAlias(AUTH_KEY_ALIAS)) {
             generateSecretKey();
             storeAuthKeyTypes(expectedAuthTypes);
+            storeAuthKeyTypesScheme(BiometricAuthenticatorConfig.KEY_AUTH_TYPES_SCHEME_VERSION);
         }
         try {
             return (SecretKey) keyStore.getKey(AUTH_KEY_ALIAS, null);
@@ -365,11 +373,17 @@ public class AuthActivity extends AppCompatActivity {
         ks.load(null);
 
         if (ks.containsAlias(alias)) {
-            // If the caller asked for a different auth model than the one the existing key was
-            // generated with (per-operation vs. time-based validity window), the key must be
-            // regenerated so the new setUserAuthenticationParameters() take effect — Keystore
-            // does not allow changing these parameters on an existing key.
-            if (getStoredAuthValidityDuration(server) != authValidityDuration) {
+            int storedScheme = getStoredCredentialAuthScheme(server);
+            if (storedScheme < BiometricAuthenticatorConfig.KEY_AUTH_TYPES_SCHEME_VERSION) {
+                // Pre-mapping keys used plugin flags as KeyProperties values; ciphertext cannot be
+                // migrated in place, so drop the legacy key and stored payload and let the caller
+                // re-enroll via setSecureCredentials / setSecureData.
+                recoverCredentialKeyFromLegacyScheme(server, ks);
+            } else if (getStoredAuthValidityDuration(server) != authValidityDuration) {
+                // If the caller asked for a different auth model than the one the existing key was
+                // generated with (per-operation vs. time-based validity window), the key must be
+                // regenerated so the new setUserAuthenticationParameters() take effect — Keystore
+                // does not allow changing these parameters on an existing key.
                 ks.deleteEntry(alias);
             } else {
                 return (SecretKey) ks.getKey(alias, null);
@@ -396,7 +410,20 @@ public class AuthActivity extends AppCompatActivity {
             }
         }
         storeAuthValidityDuration(server, authValidityDuration);
+        storeCredentialAuthScheme(server, BiometricAuthenticatorConfig.KEY_AUTH_TYPES_SCHEME_VERSION);
         return key;
+    }
+
+    private void recoverCredentialKeyFromLegacyScheme(String server, KeyStore keyStore) throws GeneralSecurityException, IOException {
+        String alias = SECURE_KEY_PREFIX + server;
+        if (keyStore.containsAlias(alias)) {
+            keyStore.deleteEntry(alias);
+        }
+        SharedPreferences.Editor editor = getSharedPreferences(SHARED_PREFS_NAME, MODE_PRIVATE).edit();
+        editor.remove("secure_" + server);
+        editor.remove("secure_" + server + SECURE_VALIDITY_SUFFIX);
+        editor.remove("secure_" + server + SECURE_AUTH_SCHEME_SUFFIX);
+        editor.apply();
     }
 
     private SecretKey buildCredentialKey(String alias, boolean invalidatedByEnrollment, int authValidityDuration)
@@ -738,5 +765,20 @@ public class AuthActivity extends AppCompatActivity {
 
     private void storeAuthKeyTypes(int authTypes) {
         getSharedPreferences(SHARED_PREFS_NAME, MODE_PRIVATE).edit().putInt(AUTH_KEY_AUTH_TYPES, authTypes).apply();
+    }
+
+    private void storeAuthKeyTypesScheme(int schemeVersion) {
+        getSharedPreferences(SHARED_PREFS_NAME, MODE_PRIVATE).edit().putInt(AUTH_KEY_AUTH_TYPES_SCHEME, schemeVersion).apply();
+    }
+
+    private int getStoredCredentialAuthScheme(String server) {
+        return getSharedPreferences(SHARED_PREFS_NAME, MODE_PRIVATE).getInt("secure_" + server + SECURE_AUTH_SCHEME_SUFFIX, 0);
+    }
+
+    private void storeCredentialAuthScheme(String server, int schemeVersion) {
+        getSharedPreferences(SHARED_PREFS_NAME, MODE_PRIVATE)
+            .edit()
+            .putInt("secure_" + server + SECURE_AUTH_SCHEME_SUFFIX, schemeVersion)
+            .apply();
     }
 }

--- a/android/src/main/java/ee/forgr/biometric/AuthActivity.java
+++ b/android/src/main/java/ee/forgr/biometric/AuthActivity.java
@@ -6,6 +6,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.security.keystore.KeyGenParameterSpec;
+import android.security.keystore.KeyInfo;
 import android.security.keystore.KeyPermanentlyInvalidatedException;
 import android.security.keystore.KeyProperties;
 import android.security.keystore.UserNotAuthenticatedException;
@@ -30,6 +31,7 @@ import java.util.concurrent.Executor;
 import javax.crypto.Cipher;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.GCMParameterSpec;
 import org.json.JSONObject;
 
@@ -375,9 +377,19 @@ public class AuthActivity extends AppCompatActivity {
 
         if (ks.containsAlias(alias)) {
             int storedScheme = getStoredCredentialAuthScheme(server);
-            if (storedScheme > 0 && storedScheme < BiometricAuthenticatorConfig.KEY_AUTH_TYPES_SCHEME_VERSION) {
-                // Only keys explicitly tagged with an outdated scheme are recovered here. Missing
-                // metadata (0) may be a pre-API-30 key that never used setUserAuthenticationParameters.
+            Integer keystoreAuthType = null;
+            Integer validityDurationSeconds = null;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                CredentialKeyAuthInfo info = readCredentialKeyAuthInfo(ks, alias);
+                keystoreAuthType = info.authType;
+                validityDurationSeconds = info.validityDurationSeconds;
+            }
+            if (BiometricAuthenticatorConfig.shouldRecoverLegacyCredentialKey(
+                storedScheme,
+                Build.VERSION.SDK_INT,
+                keystoreAuthType,
+                validityDurationSeconds
+            )) {
                 recoverCredentialKeyFromLegacyScheme(server, ks);
             } else if (getStoredAuthValidityDuration(server) != authValidityDuration) {
                 // If the caller asked for a different auth model than the one the existing key was
@@ -436,6 +448,36 @@ public class AuthActivity extends AppCompatActivity {
             return accessControl;
         }
         return getStoredAccessControl(server);
+    }
+
+    private static final class CredentialKeyAuthInfo {
+        final Integer authType;
+        final Integer validityDurationSeconds;
+
+        CredentialKeyAuthInfo(Integer authType, Integer validityDurationSeconds) {
+            this.authType = authType;
+            this.validityDurationSeconds = validityDurationSeconds;
+        }
+    }
+
+    private CredentialKeyAuthInfo readCredentialKeyAuthInfo(KeyStore keyStore, String alias) {
+        try {
+            SecretKey key = (SecretKey) keyStore.getKey(alias, null);
+            if (key == null) {
+                return new CredentialKeyAuthInfo(null, null);
+            }
+            SecretKeyFactory factory = SecretKeyFactory.getInstance(key.getAlgorithm(), "AndroidKeyStore");
+            KeyInfo info = (KeyInfo) factory.getKeySpec(key, KeyInfo.class);
+            Integer authType = null;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                authType = info.getUserAuthenticationType();
+            }
+            return new CredentialKeyAuthInfo(authType, info.getUserAuthenticationValidityDurationSeconds());
+        } catch (GeneralSecurityException | RuntimeException e) {
+            // Unreadable KeyInfo: treat as unconfirmed so the caller recovers rather than
+            // keeping a key that a strong-biometric prompt cannot satisfy.
+            return new CredentialKeyAuthInfo(null, null);
+        }
     }
 
     private void recoverCredentialKeyFromLegacyScheme(String server, KeyStore keyStore) throws GeneralSecurityException, IOException {

--- a/android/src/main/java/ee/forgr/biometric/BiometricAuthenticatorConfig.java
+++ b/android/src/main/java/ee/forgr/biometric/BiometricAuthenticatorConfig.java
@@ -25,6 +25,13 @@ public final class BiometricAuthenticatorConfig {
     public static final int PROMPT_BIOMETRIC_ANY =
         BiometricManager.Authenticators.BIOMETRIC_STRONG | BiometricManager.Authenticators.BIOMETRIC_WEAK;
 
+    /**
+     * Stored alongside Keystore auth-key metadata. Version 0 (missing) means plugin {@code KEY_AUTH_*}
+     * flags were passed straight into {@code setUserAuthenticationParameters}; version 1 maps through
+     * {@link #toKeyPropertiesAuthTypes(int)} first.
+     */
+    public static final int KEY_AUTH_TYPES_SCHEME_VERSION = 1;
+
     public final int promptAuthenticators;
     public final int keyAuthTypes;
     public final boolean allowNegativeButton;

--- a/android/src/main/java/ee/forgr/biometric/BiometricAuthenticatorConfig.java
+++ b/android/src/main/java/ee/forgr/biometric/BiometricAuthenticatorConfig.java
@@ -187,4 +187,49 @@ public final class BiometricAuthenticatorConfig {
         }
         return types == 0 ? KeyProperties.AUTH_BIOMETRIC_STRONG : types;
     }
+
+    /**
+     * Whether a stored credential Keystore key should be recovered (deleted and its ciphertext
+     * dropped) because it may have been minted with unmapped plugin {@code KEY_AUTH_*} flags.
+     * <p>
+     * Missing scheme metadata ({@code 0}) is ambiguous: pre-API-30 keys never called
+     * {@code setUserAuthenticationParameters}, while API 30+ keys created before the mapping
+     * passed plugin {@code KEY_AUTH_BIOMETRIC_STRONG} ({@code 1}) straight through, which Keystore
+     * interprets as {@code AUTH_DEVICE_CREDENTIAL}. Preserve the key only when a pre-API-30
+     * authentication configuration is confirmed; otherwise recover. Explicitly outdated scheme
+     * versions are always recovered.
+     *
+     * @param storedScheme persisted scheme version, or 0 if missing
+     * @param sdkInt {@code Build.VERSION.SDK_INT}
+     * @param keystoreAuthType {@code KeyInfo.getUserAuthenticationType()}, or null if unknown
+     * @param validityDurationSeconds {@code KeyInfo.getUserAuthenticationValidityDurationSeconds()},
+     *     or null if unknown. The old API stores {@code -1} for per-operation keys; the new API stores {@code 0}.
+     */
+    static boolean shouldRecoverLegacyCredentialKey(
+        int storedScheme,
+        int sdkInt,
+        Integer keystoreAuthType,
+        Integer validityDurationSeconds
+    ) {
+        if (storedScheme >= KEY_AUTH_TYPES_SCHEME_VERSION) {
+            return false;
+        }
+        if (storedScheme > 0) {
+            return true;
+        }
+        // storedScheme == 0: missing metadata.
+        if (sdkInt < Build.VERSION_CODES.R) {
+            return false;
+        }
+        // Confirmed pre-API-30 per-operation key (setUserAuthenticationValidityDurationSeconds(-1)).
+        if (validityDurationSeconds != null && validityDurationSeconds == -1) {
+            return false;
+        }
+        // Confirmed biometric (or biometric+PIN) configuration: pre-API-30 time-based keys and
+        // already-mapped API 30+ keys. Unmapped plugin STRONG (1) is DEVICE_CREDENTIAL-only.
+        if (keystoreAuthType != null && (keystoreAuthType & KeyProperties.AUTH_BIOMETRIC_STRONG) != 0) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/android/src/main/java/ee/forgr/biometric/BiometricAuthenticatorConfig.java
+++ b/android/src/main/java/ee/forgr/biometric/BiometricAuthenticatorConfig.java
@@ -2,6 +2,7 @@ package ee.forgr.biometric;
 
 import android.os.Build;
 import android.security.keystore.KeyProperties;
+import androidx.annotation.RequiresApi;
 import androidx.biometric.BiometricManager;
 
 /**
@@ -154,5 +155,29 @@ public final class BiometricAuthenticatorConfig {
             return KEY_AUTH_DEVICE_CREDENTIAL;
         }
         return 0;
+    }
+
+    /**
+     * Translates this class's {@code KEY_AUTH_*} flags into the {@code KeyProperties.AUTH_*} values
+     * that {@code KeyGenParameterSpec.Builder#setUserAuthenticationParameters} expects. The two sets
+     * use different bit values ({@code KEY_AUTH_BIOMETRIC_STRONG} is 1, but
+     * {@code KeyProperties.AUTH_DEVICE_CREDENTIAL} is 1 and {@code AUTH_BIOMETRIC_STRONG} is 2), so
+     * passing the plugin flags straight through mints a device-credential key for a
+     * biometric-only request — a biometric auth token then cannot satisfy it, and Android exempts
+     * such keys from biometric-enrollment invalidation.
+     * <p>
+     * Keystore keys can only be bound to Class 3 (Strong) biometrics, so {@code KEY_AUTH_BIOMETRIC_WEAK}
+     * collapses to {@code AUTH_BIOMETRIC_STRONG}.
+     */
+    @RequiresApi(Build.VERSION_CODES.R)
+    static int toKeyPropertiesAuthTypes(int pluginTypes) {
+        int types = 0;
+        if ((pluginTypes & (KEY_AUTH_BIOMETRIC_STRONG | KEY_AUTH_BIOMETRIC_WEAK)) != 0) {
+            types |= KeyProperties.AUTH_BIOMETRIC_STRONG;
+        }
+        if ((pluginTypes & KEY_AUTH_DEVICE_CREDENTIAL) != 0) {
+            types |= KeyProperties.AUTH_DEVICE_CREDENTIAL;
+        }
+        return types == 0 ? KeyProperties.AUTH_BIOMETRIC_STRONG : types;
     }
 }

--- a/android/src/main/java/ee/forgr/biometric/NativeBiometric.java
+++ b/android/src/main/java/ee/forgr/biometric/NativeBiometric.java
@@ -555,6 +555,7 @@ public class NativeBiometric extends Plugin {
                 editor.remove(KEY_ALIAS + "-password");
                 editor.remove("secure_" + KEY_ALIAS);
                 editor.remove("secure_" + KEY_ALIAS + "_validity");
+                editor.remove("secure_" + KEY_ALIAS + "_auth_scheme");
                 editor.apply();
 
                 try {
@@ -728,6 +729,7 @@ public class NativeBiometric extends Plugin {
             editor.remove(storageKey);
             editor.remove("secure_" + storageKey);
             editor.remove("secure_" + storageKey + "_validity");
+            editor.remove("secure_" + storageKey + "_auth_scheme");
             editor.apply();
 
             try {

--- a/android/src/main/java/ee/forgr/biometric/NativeBiometric.java
+++ b/android/src/main/java/ee/forgr/biometric/NativeBiometric.java
@@ -556,6 +556,7 @@ public class NativeBiometric extends Plugin {
                 editor.remove("secure_" + KEY_ALIAS);
                 editor.remove("secure_" + KEY_ALIAS + "_validity");
                 editor.remove("secure_" + KEY_ALIAS + "_auth_scheme");
+                editor.remove("secure_" + KEY_ALIAS + "_access_control");
                 editor.apply();
 
                 try {
@@ -730,6 +731,7 @@ public class NativeBiometric extends Plugin {
             editor.remove("secure_" + storageKey);
             editor.remove("secure_" + storageKey + "_validity");
             editor.remove("secure_" + storageKey + "_auth_scheme");
+            editor.remove("secure_" + storageKey + "_access_control");
             editor.apply();
 
             try {

--- a/android/src/test/java/ee/forgr/biometric/BiometricAuthenticatorConfigTest.java
+++ b/android/src/test/java/ee/forgr/biometric/BiometricAuthenticatorConfigTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import android.security.keystore.KeyProperties;
 import androidx.biometric.BiometricManager;
 import org.junit.Test;
 
@@ -92,5 +93,31 @@ public class BiometricAuthenticatorConfigTest {
 
         assertEquals(BiometricAuthenticatorConfig.PROMPT_BIOMETRIC_ANY, face.promptAuthenticators);
         assertEquals(BiometricManager.Authenticators.BIOMETRIC_STRONG, config.promptAuthenticators);
+    }
+
+    @Test
+    public void keyAuthStrong_mapsToKeyPropertiesBiometricStrong() {
+        // Plugin flag 1 is NOT KeyProperties.AUTH_DEVICE_CREDENTIAL (also 1).
+        assertEquals(KeyProperties.AUTH_BIOMETRIC_STRONG, BiometricAuthenticatorConfig.toKeyPropertiesAuthTypes(1));
+    }
+
+    @Test
+    public void keyAuthWeak_collapsesToBiometricStrong() {
+        assertEquals(KeyProperties.AUTH_BIOMETRIC_STRONG, BiometricAuthenticatorConfig.toKeyPropertiesAuthTypes(2));
+        assertEquals(KeyProperties.AUTH_BIOMETRIC_STRONG, BiometricAuthenticatorConfig.toKeyPropertiesAuthTypes(1 | 2));
+    }
+
+    @Test
+    public void keyAuthDeviceCredential_mapsToKeyPropertiesDeviceCredential() {
+        assertEquals(KeyProperties.AUTH_DEVICE_CREDENTIAL, BiometricAuthenticatorConfig.toKeyPropertiesAuthTypes(4));
+        assertEquals(
+            KeyProperties.AUTH_BIOMETRIC_STRONG | KeyProperties.AUTH_DEVICE_CREDENTIAL,
+            BiometricAuthenticatorConfig.toKeyPropertiesAuthTypes(1 | 4)
+        );
+    }
+
+    @Test
+    public void keyAuthZero_fallsBackToBiometricStrong() {
+        assertEquals(KeyProperties.AUTH_BIOMETRIC_STRONG, BiometricAuthenticatorConfig.toKeyPropertiesAuthTypes(0));
     }
 }

--- a/android/src/test/java/ee/forgr/biometric/BiometricAuthenticatorConfigTest.java
+++ b/android/src/test/java/ee/forgr/biometric/BiometricAuthenticatorConfigTest.java
@@ -120,4 +120,9 @@ public class BiometricAuthenticatorConfigTest {
     public void keyAuthZero_fallsBackToBiometricStrong() {
         assertEquals(KeyProperties.AUTH_BIOMETRIC_STRONG, BiometricAuthenticatorConfig.toKeyPropertiesAuthTypes(0));
     }
+
+    @Test
+    public void keyAuthTypesSchemeVersion_isPositive() {
+        assertTrue(BiometricAuthenticatorConfig.KEY_AUTH_TYPES_SCHEME_VERSION > 0);
+    }
 }

--- a/android/src/test/java/ee/forgr/biometric/BiometricAuthenticatorConfigTest.java
+++ b/android/src/test/java/ee/forgr/biometric/BiometricAuthenticatorConfigTest.java
@@ -125,4 +125,59 @@ public class BiometricAuthenticatorConfigTest {
     public void keyAuthTypesSchemeVersion_isPositive() {
         assertTrue(BiometricAuthenticatorConfig.KEY_AUTH_TYPES_SCHEME_VERSION > 0);
     }
+
+    @Test
+    public void currentScheme_isNotRecovered() {
+        assertFalse(
+            BiometricAuthenticatorConfig.shouldRecoverLegacyCredentialKey(
+                BiometricAuthenticatorConfig.KEY_AUTH_TYPES_SCHEME_VERSION,
+                30,
+                KeyProperties.AUTH_DEVICE_CREDENTIAL,
+                0
+            )
+        );
+    }
+
+    @Test
+    public void missingScheme_onPreApi30_isPreserved() {
+        assertFalse(BiometricAuthenticatorConfig.shouldRecoverLegacyCredentialKey(0, 29, null, null));
+    }
+
+    @Test
+    public void missingScheme_preApi30PerOperationKey_isPreserved() {
+        assertFalse(
+            BiometricAuthenticatorConfig.shouldRecoverLegacyCredentialKey(0, 30, KeyProperties.AUTH_BIOMETRIC_STRONG, -1)
+        );
+    }
+
+    @Test
+    public void missingScheme_biometricStrongKey_isPreserved() {
+        assertFalse(
+            BiometricAuthenticatorConfig.shouldRecoverLegacyCredentialKey(0, 30, KeyProperties.AUTH_BIOMETRIC_STRONG, 0)
+        );
+    }
+
+    @Test
+    public void missingScheme_preApi30TimeBasedKey_isPreserved() {
+        assertFalse(
+            BiometricAuthenticatorConfig.shouldRecoverLegacyCredentialKey(
+                0,
+                30,
+                KeyProperties.AUTH_BIOMETRIC_STRONG | KeyProperties.AUTH_DEVICE_CREDENTIAL,
+                30
+            )
+        );
+    }
+
+    @Test
+    public void missingScheme_unmappedStrongAsDeviceCredential_isRecovered() {
+        assertTrue(
+            BiometricAuthenticatorConfig.shouldRecoverLegacyCredentialKey(0, 30, KeyProperties.AUTH_DEVICE_CREDENTIAL, 0)
+        );
+    }
+
+    @Test
+    public void missingScheme_unreadableKeyInfoOnApi30_isRecovered() {
+        assertTrue(BiometricAuthenticatorConfig.shouldRecoverLegacyCredentialKey(0, 30, null, null));
+    }
 }

--- a/android/src/test/java/ee/forgr/biometric/BiometricAuthenticatorConfigTest.java
+++ b/android/src/test/java/ee/forgr/biometric/BiometricAuthenticatorConfigTest.java
@@ -145,16 +145,12 @@ public class BiometricAuthenticatorConfigTest {
 
     @Test
     public void missingScheme_preApi30PerOperationKey_isPreserved() {
-        assertFalse(
-            BiometricAuthenticatorConfig.shouldRecoverLegacyCredentialKey(0, 30, KeyProperties.AUTH_BIOMETRIC_STRONG, -1)
-        );
+        assertFalse(BiometricAuthenticatorConfig.shouldRecoverLegacyCredentialKey(0, 30, KeyProperties.AUTH_BIOMETRIC_STRONG, -1));
     }
 
     @Test
     public void missingScheme_biometricStrongKey_isPreserved() {
-        assertFalse(
-            BiometricAuthenticatorConfig.shouldRecoverLegacyCredentialKey(0, 30, KeyProperties.AUTH_BIOMETRIC_STRONG, 0)
-        );
+        assertFalse(BiometricAuthenticatorConfig.shouldRecoverLegacyCredentialKey(0, 30, KeyProperties.AUTH_BIOMETRIC_STRONG, 0));
     }
 
     @Test
@@ -171,9 +167,7 @@ public class BiometricAuthenticatorConfigTest {
 
     @Test
     public void missingScheme_unmappedStrongAsDeviceCredential_isRecovered() {
-        assertTrue(
-            BiometricAuthenticatorConfig.shouldRecoverLegacyCredentialKey(0, 30, KeyProperties.AUTH_DEVICE_CREDENTIAL, 0)
-        );
+        assertTrue(BiometricAuthenticatorConfig.shouldRecoverLegacyCredentialKey(0, 30, KeyProperties.AUTH_DEVICE_CREDENTIAL, 0));
     }
 
     @Test


### PR DESCRIPTION
Same-repo copy of fork PR #117, so required CI can run without the fork `action_required` gate.

Fork PR left open: https://github.com/Cap-go/capacitor-native-biometric/pull/117
Head: `3132c94` on `Cap-go/fix/android-key-auth-type-mapping`

## What
Map plugin `KEY_AUTH_*` flags to `KeyProperties.AUTH_*` at Keystore call sites. Version stored auth-scheme metadata and migrate existing aliases so old biometric-only keys are not left on the previous `AUTH_DEVICE_CREDENTIAL` mapping.

## Compatibility
Additive migration only. Existing public plugin APIs unchanged.

## Notes
- Fork #117 threads are resolved on `4e4fab9`; this branch carries the same plugin code plus Cap-go CI workflow so builds actually run.
- Prefer this PR once CLEAN + CR APPROVED on HEAD + 0 threads.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-native-biometric/pr/118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790413786&installation_model_id=430928&pr_number=118&repository=Cap-go%2Fcapacitor-native-biometric&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-native-biometric%2Fpull%2F118&signature=5987f0815b80ac26a706bfec9e0a401ff8ed630291aa2023a842436dec172397"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-native-biometric/pull/118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android authentication handling by correctly mapping biometric and device credential types.
  * Automatically refreshes outdated or incompatible authentication keys, including legacy keys that require recovery.
  * Ensures related authentication settings are fully cleared when credentials or data are deleted.
* **Tests**
  * Added coverage for authentication type mapping, key recovery, and key scheme version handling.
* **Chores**
  * Extended automated validation to run on an additional development branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->